### PR TITLE
feat!: change EntryID from int to uint64

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -43,8 +43,9 @@ type Schedule interface {
 	Next(time.Time) time.Time
 }
 
-// EntryID identifies an entry within a Cron instance
-type EntryID int
+// EntryID identifies an entry within a Cron instance.
+// Using uint64 prevents overflow and ID collisions on all platforms.
+type EntryID uint64
 
 // Entry consists of a schedule and the func to execute on that schedule.
 type Entry struct {


### PR DESCRIPTION
## Summary
- Changes `EntryID` type from `int` to `uint64` to prevent overflow on 32-bit systems
- Adds documentation explaining the rationale

## Problem
On 32-bit systems, `int` can overflow after ~248 days at 100 jobs/sec, causing ID collisions that could result in wrong job removal.

## Solution
Use `uint64` which provides consistent behavior across all platforms and eliminates overflow risk.

## Breaking Change
`EntryID` type signature changes from `int` to `uint64`. Most code using `EntryID` will continue to work unchanged since Go handles numeric type conversions implicitly in many contexts.

## Test plan
- [x] All existing tests pass
- [x] golangci-lint shows 0 issues

Closes #7