### PR TITLE
feat: add slog adapter for structured logging

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -3,6 +3,7 @@ package cron
 import (
 	"io"
 	"log"
+	"log/slog"
 	"os"
 	"strings"
 	"time"
@@ -83,4 +84,27 @@ func formatTimes(keysAndValues []interface{}) []interface{} {
 		formattedArgs = append(formattedArgs, arg)
 	}
 	return formattedArgs
+}
+
+// SlogLogger adapts log/slog to the Logger interface.
+// This allows integration with Go 1.21+ structured logging.
+type SlogLogger struct {
+	logger *slog.Logger
+}
+
+// NewSlogLogger creates a Logger that writes to the given slog.Logger.
+// If l is nil, slog.Default() is used.
+func NewSlogLogger(l *slog.Logger) *SlogLogger {
+	if l == nil {
+		l = slog.Default()
+	}
+	return &SlogLogger{logger: l}
+}
+
+func (s *SlogLogger) Info(msg string, keysAndValues ...interface{}) {
+	s.logger.Info(msg, keysAndValues...)
+}
+
+func (s *SlogLogger) Error(err error, msg string, keysAndValues ...interface{}) {
+	s.logger.Error(msg, append([]interface{}{"error", err}, keysAndValues...)...)
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,63 @@
+package cron
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestSlogLoggerInfo(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	sl := NewSlogLogger(logger)
+
+	sl.Info("test message", "key", "value")
+
+	output := buf.String()
+	if !strings.Contains(output, "test message") {
+		t.Errorf("expected output to contain 'test message', got: %s", output)
+	}
+	if !strings.Contains(output, "key=value") {
+		t.Errorf("expected output to contain 'key=value', got: %s", output)
+	}
+}
+
+func TestSlogLoggerError(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError}))
+	sl := NewSlogLogger(logger)
+
+	testErr := &testError{msg: "test error"}
+	sl.Error(testErr, "error message", "key", "value")
+
+	output := buf.String()
+	if !strings.Contains(output, "error message") {
+		t.Errorf("expected output to contain 'error message', got: %s", output)
+	}
+	if !strings.Contains(output, "error=") {
+		t.Errorf("expected output to contain 'error=', got: %s", output)
+	}
+	if !strings.Contains(output, "key=value") {
+		t.Errorf("expected output to contain 'key=value', got: %s", output)
+	}
+}
+
+func TestSlogLoggerNilDefault(t *testing.T) {
+	// Should not panic when nil is passed and should use slog.Default()
+	sl := NewSlogLogger(nil)
+	// Verify it works by calling Info (would panic if logger was nil)
+	sl.Info("test with nil logger")
+}
+
+func TestSlogLoggerImplementsInterface(t *testing.T) {
+	var _ Logger = (*SlogLogger)(nil)
+}
+
+type testError struct {
+	msg string
+}
+
+func (e *testError) Error() string {
+	return e.msg
+}


### PR DESCRIPTION
## Summary
- Adds `SlogLogger` type that adapts `log/slog` (Go 1.21+) to the cron `Logger` interface
- Maintains backward compatibility with existing Logger implementations
- Allows seamless integration with Go's standard structured logging

## Implementation
```go
// Create slog adapter
logger := cron.NewSlogLogger(slog.Default())

// Use with cron
c := cron.New(cron.WithLogger(logger))
```

## Test plan
- [x] TestSlogLoggerInfo - verifies Info method works
- [x] TestSlogLoggerError - verifies Error method with error field
- [x] TestSlogLoggerNilDefault - verifies nil fallback to slog.Default()
- [x] TestSlogLoggerImplementsInterface - compile-time interface check
- [x] golangci-lint shows 0 issues

Closes #8