### PR TITLE
fix(parser): panic when NewParser called with no fields

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -68,6 +68,17 @@ type Parser struct {
 //	specParser := NewParser(Dom | Month | DowOptional)
 //	sched, err := specParser.Parse("15 */3")
 func NewParser(options ParseOption) Parser {
+	// Count how many regular fields are configured
+	fields := 0
+	for _, place := range places {
+		if options&place > 0 {
+			fields++
+		}
+	}
+	if fields == 0 && options&Descriptor == 0 {
+		panic("at least one field or Descriptor must be configured")
+	}
+
 	optionals := 0
 	if options&DowOptional > 0 {
 		optionals++

--- a/parser_test.go
+++ b/parser_test.go
@@ -403,6 +403,31 @@ func TestNoDescriptorParser(t *testing.T) {
 	}
 }
 
+func TestNewParserPanicsWithNoFields(t *testing.T) {
+	// Test that NewParser panics when called with no fields
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("NewParser(0) should panic with no fields configured")
+		}
+	}()
+	NewParser(0)
+}
+
+func TestNewParserDescriptorOnlyValid(t *testing.T) {
+	// Test that NewParser with only Descriptor is valid
+	// (even though it only accepts @descriptors)
+	parser := NewParser(Descriptor)
+	_, err := parser.Parse("@daily")
+	if err != nil {
+		t.Errorf("expected @daily to parse with Descriptor-only parser, got: %v", err)
+	}
+
+	_, err = parser.Parse("* * * * *")
+	if err == nil {
+		t.Error("expected cron expression to fail with Descriptor-only parser")
+	}
+}
+
 func every5min(loc *time.Location) *SpecSchedule {
 	return &SpecSchedule{1 << 0, 1 << 5, all(hours), all(dom), all(months), all(dow), loc}
 }


### PR DESCRIPTION
## Summary
- `NewParser(0)` now panics with "at least one field or Descriptor must be configured"
- This prevents creating a parser that silently accepts empty/whitespace input and returns invalid schedules
- A parser with only `Descriptor` flag is still valid as it can parse @descriptors

## Problem
Previously `NewParser(0).Parse("   ")` would return a schedule using all default values instead of an error. This was misleading and could cause subtle bugs.

## Upstream Reference
Addresses robfig/cron#555 - Parser panics when called with timezone-only spec or missing fields.

## Test plan
- [x] Test verifies `NewParser(0)` panics
- [x] Test verifies `NewParser(Descriptor)` is valid and can parse @daily
- [x] All existing tests continue to pass
- [x] Linter passes

Closes #21