### PR TITLE
feat: add WithClock option for custom time source injection

### DIFF
--- a/option.go
+++ b/option.go
@@ -43,3 +43,22 @@ func WithLogger(logger Logger) Option {
 		c.logger = logger
 	}
 }
+
+// WithClock uses the provided clock function instead of time.Now.
+// This is useful for testing time-dependent behavior without waiting.
+//
+// Example usage:
+//
+//	// For testing, use a fixed time
+//	fixedTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+//	c := cron.New(cron.WithClock(func() time.Time { return fixedTime }))
+//
+//	// Or advance time manually
+//	var currentTime atomic.Value
+//	currentTime.Store(time.Now())
+//	c := cron.New(cron.WithClock(func() time.Time { return currentTime.Load().(time.Time) }))
+func WithClock(clock Clock) Option {
+	return func(c *Cron) {
+		c.clock = clock
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Clock` type (`func() time.Time`) for custom time functions
- Add `WithClock` Option to inject custom time source into Cron
- Update `now()` method to use custom clock when configured
- Add comprehensive tests for clock functionality

## Motivation
Addresses #4 - Custom time source injection

Testing cron scheduling logic often requires control over time. The existing implementation always uses `time.Now()`, making tests either slow (waiting for real time) or requiring complex mocking.

This feature allows injecting a custom time source, enabling:
- Deterministic tests with fixed timestamps
- Fast-forwarding time in tests
- Simulating specific dates/times for edge cases

## Usage

```go
// Fixed time for testing
fixedTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
c := cron.New(cron.WithClock(func() time.Time { return fixedTime }))

// Or with controllable time
var currentTime atomic.Value
currentTime.Store(time.Now())
c := cron.New(cron.WithClock(func() time.Time { return currentTime.Load().(time.Time) }))
```

## Test plan
- [x] `TestWithClock` - verify clock is set and used
- [x] `TestWithClockAndLocation` - verify clock respects location setting
- [x] `TestWithClockNilFallback` - verify default behavior when no clock set
- [x] All existing tests pass
- [x] Race detection passes
- [x] Linter passes

Closes #4