### PR TITLE
fix(scheduler): iterate over copy when handling time backwards

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -274,7 +274,10 @@ func (c *Cron) run() {
 
 				// Handle system time moving backwards (NTP correction, VM snapshot restore).
 				// If Prev is in the future relative to now, time moved backwards.
-				for _, e := range c.entries {
+				// Iterate over a copy since Update() reorders the heap.
+				entriesCopy := make([]*Entry, len(c.entries))
+				copy(entriesCopy, c.entries)
+				for _, e := range entriesCopy {
 					if !e.Prev.IsZero() && e.Prev.After(now) {
 						e.Next = e.Schedule.Next(now)
 						c.entries.Update(e)


### PR DESCRIPTION
## Summary
Fix range loop modification bug in time-backwards handling code.

## Problem
The for-range loop iterates over `c.entries` while calling `Update()`, which reorders elements via `heap.Fix()`. This could cause entries to be visited twice or skipped.

## Solution
Iterate over a copy of the entries slice, ensuring all entries are checked exactly once.

## Upstream Reference
Addresses robfig/cron#480 - PR implementing time backwards handling. This fix improves the robustness of time-backwards scenarios.

## Test plan
- [x] All existing tests pass with race detector
- [x] Change is defensive - only affects rare time-backwards scenario

Fixes #40