### PR TITLE
fix(scheduler): skip EntryID 0 on uint64 overflow

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -165,6 +165,9 @@ func (c *Cron) Schedule(schedule Schedule, cmd Job) EntryID {
 	c.runningMu.Lock()
 	defer c.runningMu.Unlock()
 	c.nextID++
+	if c.nextID == 0 {
+		c.nextID = 1 // Skip 0; Entry.Valid() uses 0 as invalid sentinel
+	}
 	entry := &Entry{
 		ID:         c.nextID,
 		Schedule:   schedule,


### PR DESCRIPTION
## Summary
Skip EntryID 0 when nextID overflows from uint64 max to preserve Entry.Valid() semantics.

## Problem
- `EntryID` is `uint64`, incrementing can overflow to 0
- `Entry.Valid()` uses `ID != 0` as invalid check
- After overflow, new entries would have ID=0 and appear invalid

## Solution
Skip ID 0 on overflow:
```go
c.nextID++
if c.nextID == 0 {
    c.nextID = 1  // Skip 0
}
```

## Upstream Reference
Addresses robfig/cron#347 - int overflow issues with EntryID. Our solution changes EntryID from `int` to `uint64` and handles the overflow edge case.

## Impact
- Theoretically unreachable: 584,942 years at 1M entries/sec
- Zero performance cost (single comparison)
- Defensive programming best practice

## Test plan
- [x] All tests pass with race detector

Fixes #42