### PR TITLE
docs: document magic numbers and add named constants

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -8,6 +8,12 @@ import (
 	"time"
 )
 
+// maxIdleDuration is the sleep duration when no entries are scheduled.
+// Using a very long duration (~11.4 years) instead of blocking indefinitely
+// allows the scheduler loop to still respond to add, remove, and stop operations.
+// This is a practical "infinity" that avoids timer overflow concerns.
+const maxIdleDuration = 100000 * time.Hour
+
 // Cron keeps track of any number of entries, invoking the associated func as
 // specified by the schedule. It may be started, stopped, and the entries may
 // be inspected while running.
@@ -279,7 +285,7 @@ func (c *Cron) run() {
 		if next == nil || next.Next.IsZero() {
 			// If there are no entries yet, just sleep - it still handles new entries
 			// and stop requests.
-			timer = c.clock.NewTimer(100000 * time.Hour)
+			timer = c.clock.NewTimer(maxIdleDuration)
 		} else {
 			timer = c.clock.NewTimer(next.Next.Sub(now))
 		}


### PR DESCRIPTION
## Summary
- Add `maxIdleDuration` constant in cron.go with explanation of why 100,000 hours is used for empty scheduler sleep
- Enhance `starBit` comment in spec.go to explain why bit 63 is chosen (avoids conflicts with valid schedule bits 0-59)
- Add `scheduleSearchYears` constant in spec.go to document the 5-year search limit for `Next()` function

## Changes
- **cron.go**: Added `maxIdleDuration` constant with documentation, replaced magic number at usage site
- **spec.go**: Enhanced `starBit` comment, added `scheduleSearchYears` constant, updated usage site

## Test plan
- [x] `go build ./...` compiles successfully
- [x] `go test ./...` passes all tests
- [x] `golangci-lint run ./...` reports no issues

Fixes #66