### PR TITLE
feat: add StopAndWait() convenience method

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -373,6 +373,17 @@ func (c *Cron) Stop() context.Context {
 	return ctx
 }
 
+// StopAndWait stops the cron scheduler and blocks until all running jobs complete.
+// This is a convenience method equivalent to:
+//
+//	ctx := c.Stop()
+//	<-ctx.Done()
+//
+// For timeout-based shutdown, use Stop() directly and select on the returned context.
+func (c *Cron) StopAndWait() {
+	<-c.Stop().Done()
+}
+
 // entrySnapshot returns a copy of the current cron entry list, sorted by next execution time.
 func (c *Cron) entrySnapshot() []Entry {
 	entries := make([]Entry, len(c.entries))


### PR DESCRIPTION
## Summary
Add `StopAndWait()` method to `Cron` that stops the scheduler and blocks until all running jobs complete.

## Changes
- **cron.go**: Added `StopAndWait()` method with documentation
- **cron_test.go**: Added 2 test cases:
  - `StopAndWait blocks until job completes` - verifies blocking behavior
  - `StopAndWait on non-running cron returns immediately` - verifies no deadlock

## Usage
```go
// Simple blocking shutdown
cron.StopAndWait()

// For timeout-based shutdown, use Stop() directly
ctx := cron.Stop()
select {
case <-ctx.Done():
case <-time.After(30 * time.Second):
}
```

## Test plan
- [x] `go build ./...` compiles successfully
- [x] `go test ./...` passes all tests (including new StopAndWait tests)
- [x] `golangci-lint run ./...` reports no issues

Fixes #67