### PR TITLE
feat: add RetryWithBackoff and CircuitBreaker job wrappers

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -1,0 +1,210 @@
+package cron
+
+import (
+	"fmt"
+	"math"
+	"sync"
+	"time"
+)
+
+// RetryWithBackoff wraps a job to retry on panic with exponential backoff.
+// A job "fails" if it panics. The wrapper catches panics and retries.
+//
+// This wrapper is useful when jobs call external services that may have
+// transient failures. Instead of waiting for the next scheduled run,
+// the job is retried immediately with increasing delays.
+//
+// Parameters:
+//   - logger: For logging retry attempts
+//   - maxRetries: Maximum retry attempts (0 = unlimited retries)
+//   - initialDelay: First retry delay
+//   - maxDelay: Maximum delay cap (prevents exponential explosion)
+//   - multiplier: Delay multiplier per retry (typically 2.0)
+//
+// Example usage:
+//
+//	c := cron.New(
+//	    cron.WithChain(
+//	        cron.Recover(logger),   // Outermost: catches final re-panics
+//	        cron.RetryWithBackoff(logger, 3, time.Second, time.Minute, 2.0),
+//	    ),
+//	)
+//	c.AddFunc("@every 5m", func() {
+//	    if err := callAPI(); err != nil {
+//	        panic(err) // Will be retried up to 3 times
+//	    }
+//	})
+//
+// Retry behavior for maxRetries=3, initialDelay=1s, multiplier=2.0:
+//
+//	| Attempt | Delay | Action            |
+//	|---------|-------|-------------------|
+//	| 1       | 0     | Execute           |
+//	| 2       | 1s    | Retry after delay |
+//	| 3       | 2s    | Retry after delay |
+//	| 4       | 4s    | Final retry       |
+//	| -       | -     | Re-panic (fail)   |
+
+// calculateBackoffDelay returns the delay for a given retry attempt using exponential backoff.
+func calculateBackoffDelay(attempt int, initialDelay, maxDelay time.Duration, multiplier float64) time.Duration {
+	delay := time.Duration(float64(initialDelay) * math.Pow(multiplier, float64(attempt-2)))
+	if delay > maxDelay {
+		return maxDelay
+	}
+	return delay
+}
+
+// runWithRecovery executes a job and returns any panic value, or nil on success.
+func runWithRecovery(j Job) (panicValue any) {
+	defer func() {
+		panicValue = recover()
+	}()
+	j.Run()
+	return nil
+}
+
+func RetryWithBackoff(logger Logger, maxRetries int, initialDelay, maxDelay time.Duration, multiplier float64) JobWrapper {
+	return func(j Job) Job {
+		return FuncJob(func() {
+			maxAttempts := maxRetries + 1 // maxRetries=3 means 4 total attempts (1 initial + 3 retries)
+			if maxRetries == 0 {
+				maxAttempts = 0 // unlimited
+			}
+
+			var lastPanic any
+			for attempt := 1; maxAttempts == 0 || attempt <= maxAttempts; attempt++ {
+				if attempt > 1 {
+					delay := calculateBackoffDelay(attempt, initialDelay, maxDelay, multiplier)
+					logger.Info("retry", "attempt", attempt, "delay", delay, "last_panic", lastPanic)
+					time.Sleep(delay)
+				}
+
+				lastPanic = runWithRecovery(j)
+				if lastPanic == nil {
+					if attempt > 1 {
+						logger.Info("retry succeeded", "attempt", attempt)
+					}
+					return // Success
+				}
+			}
+
+			// All retries exhausted
+			logger.Error(fmt.Errorf("%v", lastPanic), "retry exhausted", "attempts", maxAttempts)
+			panic(lastPanic) // Re-panic for outer wrappers to handle
+		})
+	}
+}
+
+// CircuitBreaker wraps a job to stop execution after consecutive failures.
+// This prevents a failing job from continuously hammering an external service.
+//
+// The circuit breaker has three states:
+//   - Closed: Normal execution. Failures increment counter.
+//   - Open: Execution is skipped. Entered after threshold failures.
+//   - Half-Open: After cooldown, one execution is attempted. Success closes circuit,
+//     failure reopens it.
+//
+// A job "fails" if it panics. Successful execution resets the failure counter.
+//
+// Parameters:
+//   - logger: For logging circuit state changes
+//   - threshold: Number of consecutive failures to open circuit
+//   - cooldown: Time to wait before attempting recovery (half-open state)
+//
+// Example usage:
+//
+//	c := cron.New(
+//	    cron.WithChain(
+//	        cron.Recover(logger), // Outermost: catches re-panics from circuit breaker
+//	        cron.CircuitBreaker(logger, 5, 5*time.Minute),
+//	    ),
+//	)
+//	c.AddFunc("@every 1m", func() {
+//	    if err := callAPI(); err != nil {
+//	        panic(err) // After 5 failures, circuit opens for 5 minutes
+//	    }
+//	})
+//
+// State transitions:
+//
+//	CLOSED --[threshold failures]--> OPEN --[cooldown expires]--> HALF-OPEN
+//	   ^                                                              |
+//	   |                                                              |
+//	   +------------------[success]-----------------------------------+
+//	                                                                  |
+//	                      +--[failure]--------------------------------+
+//	                      |
+//	                      v
+//	                    OPEN
+func CircuitBreaker(logger Logger, threshold int, cooldown time.Duration) JobWrapper {
+	return func(j Job) Job {
+		var (
+			failures   int
+			lastFailAt time.Time
+			mu         sync.Mutex
+		)
+
+		return FuncJob(func() {
+			mu.Lock()
+			currentFailures := failures
+			timeSinceLastFail := time.Since(lastFailAt)
+
+			// Check if circuit is open
+			if currentFailures >= threshold && timeSinceLastFail < cooldown {
+				mu.Unlock()
+				remaining := cooldown - timeSinceLastFail
+				logger.Info("circuit breaker open",
+					"failures", currentFailures,
+					"cooldown_remaining", remaining.Round(time.Second))
+				return // Skip execution
+			}
+
+			// Entering half-open state if recovering from open
+			halfOpen := currentFailures >= threshold
+			mu.Unlock()
+
+			if halfOpen {
+				logger.Info("circuit breaker half-open", "attempting_recovery", true)
+			}
+
+			// Execute with panic recovery
+			var panicked bool
+			var panicValue any
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						panicked = true
+						panicValue = r
+					}
+				}()
+				j.Run()
+			}()
+
+			mu.Lock()
+			if panicked {
+				failures++
+				lastFailAt = time.Now()
+				currentFailures = failures
+				mu.Unlock()
+
+				if currentFailures == threshold {
+					logger.Error(fmt.Errorf("%v", panicValue), "circuit breaker opened",
+						"failures", currentFailures, "cooldown", cooldown)
+				} else {
+					logger.Error(fmt.Errorf("%v", panicValue), "circuit breaker recorded failure",
+						"failures", currentFailures, "threshold", threshold)
+				}
+				panic(panicValue) // Re-panic
+			}
+
+			// Success - reset failures
+			wasOpen := failures >= threshold
+			failures = 0
+			mu.Unlock()
+
+			if wasOpen {
+				logger.Info("circuit breaker closed", "recovered", true)
+			}
+		})
+	}
+}

--- a/retry_test.go
+++ b/retry_test.go
@@ -1,0 +1,448 @@
+package cron
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestRetryWithBackoff_SuccessOnFirstAttempt(t *testing.T) {
+	var attempts int32
+
+	wrapped := RetryWithBackoff(DiscardLogger, 3, 10*time.Millisecond, time.Second, 2.0)(
+		FuncJob(func() {
+			atomic.AddInt32(&attempts, 1)
+		}),
+	)
+
+	wrapped.Run()
+
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Errorf("expected 1 attempt, got %d", got)
+	}
+}
+
+func TestRetryWithBackoff_SuccessOnRetry(t *testing.T) {
+	var attempts int32
+
+	wrapped := RetryWithBackoff(DiscardLogger, 3, 10*time.Millisecond, time.Second, 2.0)(
+		FuncJob(func() {
+			count := atomic.AddInt32(&attempts, 1)
+			if count < 3 {
+				panic("transient failure")
+			}
+		}),
+	)
+
+	wrapped.Run()
+
+	if got := atomic.LoadInt32(&attempts); got != 3 {
+		t.Errorf("expected 3 attempts, got %d", got)
+	}
+}
+
+func TestRetryWithBackoff_ExhaustsRetries(t *testing.T) {
+	var attempts int32
+
+	wrapped := RetryWithBackoff(DiscardLogger, 3, 1*time.Millisecond, time.Second, 2.0)(
+		FuncJob(func() {
+			atomic.AddInt32(&attempts, 1)
+			panic("always fails")
+		}),
+	)
+
+	// Should panic after exhausting retries
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic after retries exhausted")
+		}
+	}()
+
+	wrapped.Run()
+
+	// Should never reach here
+	t.Error("should have panicked")
+}
+
+func TestRetryWithBackoff_RetriesExhausted_AttemptCount(t *testing.T) {
+	var attempts int32
+
+	wrapped := RetryWithBackoff(DiscardLogger, 3, 1*time.Millisecond, time.Second, 2.0)(
+		FuncJob(func() {
+			atomic.AddInt32(&attempts, 1)
+			panic("always fails")
+		}),
+	)
+
+	func() {
+		defer func() { recover() }()
+		wrapped.Run()
+	}()
+
+	// maxRetries=3 means 4 total attempts (1 initial + 3 retries)
+	if got := atomic.LoadInt32(&attempts); got != 4 {
+		t.Errorf("expected 4 attempts (1 initial + 3 retries), got %d", got)
+	}
+}
+
+func TestRetryWithBackoff_BackoffTiming(t *testing.T) {
+	var timestamps []time.Time
+	var mu sync.Mutex
+
+	wrapped := RetryWithBackoff(DiscardLogger, 3, 50*time.Millisecond, time.Second, 2.0)(
+		FuncJob(func() {
+			mu.Lock()
+			timestamps = append(timestamps, time.Now())
+			mu.Unlock()
+			if len(timestamps) < 4 {
+				panic("transient")
+			}
+		}),
+	)
+
+	func() {
+		defer func() { recover() }()
+		wrapped.Run()
+	}()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(timestamps) < 4 {
+		t.Fatalf("expected at least 4 timestamps, got %d", len(timestamps))
+	}
+
+	// Check delays are increasing (exponential backoff)
+	// Expected: 0, 50ms, 100ms, 200ms
+	for i := 1; i < len(timestamps)-1; i++ {
+		prev := timestamps[i].Sub(timestamps[i-1])
+		next := timestamps[i+1].Sub(timestamps[i])
+		// Next delay should be roughly double (with some tolerance)
+		if next < prev {
+			t.Logf("delay %d: %v, delay %d: %v", i, prev, i+1, next)
+			// Allow some timing variance
+		}
+	}
+}
+
+func TestRetryWithBackoff_MaxDelayRespected(t *testing.T) {
+	var timestamps []time.Time
+	var mu sync.Mutex
+
+	maxDelay := 30 * time.Millisecond
+	wrapped := RetryWithBackoff(DiscardLogger, 10, 10*time.Millisecond, maxDelay, 2.0)(
+		FuncJob(func() {
+			mu.Lock()
+			timestamps = append(timestamps, time.Now())
+			count := len(timestamps)
+			mu.Unlock()
+			if count < 8 {
+				panic("transient")
+			}
+		}),
+	)
+
+	wrapped.Run()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// After a few retries, delay should cap at maxDelay
+	// Delays: 0, 10ms, 20ms, 30ms, 30ms, 30ms...
+	for i := 4; i < len(timestamps); i++ {
+		delay := timestamps[i].Sub(timestamps[i-1])
+		// Allow 50% variance due to timing
+		if delay > maxDelay*3/2 {
+			t.Errorf("delay at attempt %d exceeded max: %v > %v", i, delay, maxDelay)
+		}
+	}
+}
+
+func TestRetryWithBackoff_UnlimitedRetries(t *testing.T) {
+	var attempts int32
+
+	wrapped := RetryWithBackoff(DiscardLogger, 0, 1*time.Millisecond, 5*time.Millisecond, 2.0)(
+		FuncJob(func() {
+			count := atomic.AddInt32(&attempts, 1)
+			if count < 20 {
+				panic("keep trying")
+			}
+		}),
+	)
+
+	wrapped.Run()
+
+	if got := atomic.LoadInt32(&attempts); got != 20 {
+		t.Errorf("expected 20 attempts, got %d", got)
+	}
+}
+
+func TestCircuitBreaker_NormalOperation(t *testing.T) {
+	var executions int32
+
+	wrapped := CircuitBreaker(DiscardLogger, 3, time.Minute)(
+		FuncJob(func() {
+			atomic.AddInt32(&executions, 1)
+		}),
+	)
+
+	// Multiple successful executions
+	for i := 0; i < 5; i++ {
+		wrapped.Run()
+	}
+
+	if got := atomic.LoadInt32(&executions); got != 5 {
+		t.Errorf("expected 5 executions, got %d", got)
+	}
+}
+
+func TestCircuitBreaker_OpensAfterThreshold(t *testing.T) {
+	var executions int32
+
+	wrapped := CircuitBreaker(DiscardLogger, 3, time.Hour)(
+		FuncJob(func() {
+			atomic.AddInt32(&executions, 1)
+			panic("always fails")
+		}),
+	)
+
+	// Fail 3 times to open circuit
+	for i := 0; i < 3; i++ {
+		func() {
+			defer func() { recover() }()
+			wrapped.Run()
+		}()
+	}
+
+	// Circuit should be open, execution should be skipped
+	wrapped.Run()
+	wrapped.Run()
+	wrapped.Run()
+
+	// Should only have 3 executions (before circuit opened)
+	if got := atomic.LoadInt32(&executions); got != 3 {
+		t.Errorf("expected 3 executions (circuit should be open), got %d", got)
+	}
+}
+
+func TestCircuitBreaker_HalfOpenRecovery(t *testing.T) {
+	var executions int32
+	var shouldFail bool
+	var mu sync.Mutex
+
+	cooldown := 100 * time.Millisecond
+	wrapped := CircuitBreaker(DiscardLogger, 2, cooldown)(
+		FuncJob(func() {
+			atomic.AddInt32(&executions, 1)
+			mu.Lock()
+			fail := shouldFail
+			mu.Unlock()
+			if fail {
+				panic("failure")
+			}
+		}),
+	)
+
+	// Set up to fail
+	mu.Lock()
+	shouldFail = true
+	mu.Unlock()
+
+	// Fail twice to open circuit
+	for i := 0; i < 2; i++ {
+		func() {
+			defer func() { recover() }()
+			wrapped.Run()
+		}()
+	}
+
+	// Circuit is open
+	wrapped.Run() // Skipped
+
+	// Wait for cooldown
+	time.Sleep(cooldown + 10*time.Millisecond)
+
+	// Set up to succeed
+	mu.Lock()
+	shouldFail = false
+	mu.Unlock()
+
+	// Half-open: should execute and close circuit
+	wrapped.Run()
+
+	// Circuit should be closed now
+	wrapped.Run()
+	wrapped.Run()
+
+	// Expected: 2 (initial failures) + 1 (half-open recovery) + 2 (after close) = 5
+	if got := atomic.LoadInt32(&executions); got != 5 {
+		t.Errorf("expected 5 executions, got %d", got)
+	}
+}
+
+func TestCircuitBreaker_HalfOpenFailure(t *testing.T) {
+	var executions int32
+
+	cooldown := 100 * time.Millisecond
+	wrapped := CircuitBreaker(DiscardLogger, 2, cooldown)(
+		FuncJob(func() {
+			atomic.AddInt32(&executions, 1)
+			panic("always fails")
+		}),
+	)
+
+	// Fail twice to open circuit
+	for i := 0; i < 2; i++ {
+		func() {
+			defer func() { recover() }()
+			wrapped.Run()
+		}()
+	}
+
+	// Circuit is open
+	wrapped.Run() // Skipped
+
+	// Wait for cooldown
+	time.Sleep(cooldown + 10*time.Millisecond)
+
+	// Half-open: execute but fail again
+	func() {
+		defer func() { recover() }()
+		wrapped.Run()
+	}()
+
+	// Circuit should reopen
+	wrapped.Run() // Should be skipped
+
+	// Expected: 2 (initial) + 1 (half-open attempt) = 3
+	if got := atomic.LoadInt32(&executions); got != 3 {
+		t.Errorf("expected 3 executions, got %d", got)
+	}
+}
+
+func TestCircuitBreaker_SuccessResetsFailures(t *testing.T) {
+	var executions int32
+	var failCount int32
+	var mu sync.Mutex
+
+	wrapped := CircuitBreaker(DiscardLogger, 3, time.Hour)(
+		FuncJob(func() {
+			atomic.AddInt32(&executions, 1)
+			mu.Lock()
+			count := atomic.AddInt32(&failCount, 1)
+			mu.Unlock()
+			if count == 2 || count == 5 {
+				// Fail on 2nd and 5th execution
+				panic("intermittent failure")
+			}
+		}),
+	)
+
+	// Execute with some failures
+	for i := 0; i < 6; i++ {
+		func() {
+			defer func() { recover() }()
+			wrapped.Run()
+		}()
+	}
+
+	// All executions should happen because failures are reset by successes
+	if got := atomic.LoadInt32(&executions); got != 6 {
+		t.Errorf("expected 6 executions, got %d", got)
+	}
+}
+
+func TestCircuitBreaker_ConcurrentSafe(t *testing.T) {
+	var executions int32
+
+	wrapped := CircuitBreaker(DiscardLogger, 5, time.Millisecond)(
+		FuncJob(func() {
+			atomic.AddInt32(&executions, 1)
+		}),
+	)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			wrapped.Run()
+		}()
+	}
+	wg.Wait()
+
+	// All should execute since no failures
+	if got := atomic.LoadInt32(&executions); got != 100 {
+		t.Errorf("expected 100 executions, got %d", got)
+	}
+}
+
+func TestRetryWithBackoff_IntegrationWithCron(t *testing.T) {
+	clock := NewFakeClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	var executions int32
+
+	// Chain order: Recover is outermost (catches final re-panics),
+	// RetryWithBackoff is innermost (sees panics from job, retries).
+	c := New(
+		WithClock(clock),
+		WithChain(
+			Recover(DiscardLogger),
+			RetryWithBackoff(DiscardLogger, 2, 1*time.Millisecond, 10*time.Millisecond, 2.0),
+		),
+	)
+
+	c.AddFunc("@every 1h", func() {
+		count := atomic.AddInt32(&executions, 1)
+		if count < 3 {
+			panic("transient failure")
+		}
+	})
+
+	c.Start()
+	defer c.Stop()
+
+	time.Sleep(50 * time.Millisecond)
+	clock.Advance(time.Hour)
+	time.Sleep(100 * time.Millisecond)
+
+	// Should have 3 executions (2 retries + 1 success)
+	if got := atomic.LoadInt32(&executions); got != 3 {
+		t.Errorf("expected 3 executions, got %d", got)
+	}
+}
+
+func TestCircuitBreaker_IntegrationWithCron(t *testing.T) {
+	clock := NewFakeClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	var executions int32
+
+	// Chain order: Recover is outermost (catches re-panics from circuit breaker),
+	// CircuitBreaker is innermost (sees panics from job, tracks failures).
+	c := New(
+		WithClock(clock),
+		WithChain(
+			Recover(DiscardLogger),
+			CircuitBreaker(DiscardLogger, 2, time.Hour),
+		),
+	)
+
+	c.AddFunc("@every 1h", func() {
+		atomic.AddInt32(&executions, 1)
+		panic("always fails")
+	})
+
+	c.Start()
+	defer c.Stop()
+
+	// Trigger job multiple times
+	time.Sleep(50 * time.Millisecond)
+	for i := 0; i < 5; i++ {
+		clock.Advance(time.Hour)
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Should have 2 executions before circuit opens
+	if got := atomic.LoadInt32(&executions); got != 2 {
+		t.Errorf("expected 2 executions (circuit should open), got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary

Implements retry and circuit breaker patterns for improved job resilience when interacting with external services:

**RetryWithBackoff wrapper:**
- Retries jobs on panic with configurable exponential backoff
- Parameters: `maxRetries`, `initialDelay`, `maxDelay`, `multiplier`
- `maxRetries=0` enables unlimited retries until success
- Logs retry attempts, delays, and final success/failure

**CircuitBreaker wrapper:**
- Prevents failing jobs from continuously hammering external services
- Three states: Closed (normal), Open (skipping), Half-Open (testing recovery)
- Parameters: failure `threshold`, `cooldown` duration
- Success resets failure counter; successful half-open test closes circuit

**Both wrappers:**
- Use panic/recover for failure detection (consistent with existing `Recover`, `Timeout` wrappers)
- Re-panic after handling to allow outer wrappers (e.g., `Recover`) to process
- Thread-safe with per-job state via closure variables
- Include comprehensive unit tests and integration tests with `FakeClock`

Example usage:
```go
c := cron.New(
    cron.WithChain(
        cron.Recover(logger),   // Outermost: catches final re-panics
        cron.RetryWithBackoff(logger, 3, time.Second, time.Minute, 2.0),
    ),
)
```

Closes #72

## Test plan

- [x] Unit tests for RetryWithBackoff (7 tests)
- [x] Unit tests for CircuitBreaker (7 tests)
- [x] Integration tests with FakeClock
- [x] Race detector passes
- [x] Linter passes