### PR TITLE
feat: add configurable minimum interval for @every expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ features, bug fixes, and modernization improvements.
 
 ## [Unreleased]
 
+### Added
+- **WithMinEveryInterval option**: Configure minimum interval for `@every` expressions
+  - Allow sub-second intervals for testing: `WithMinEveryInterval(0)` or `WithMinEveryInterval(100*time.Millisecond)`
+  - Enforce longer minimums for rate limiting: `WithMinEveryInterval(time.Minute)`
+- **EveryWithMin function**: Create constant delay schedules with custom minimum interval
+- **Parser.WithMinEveryInterval**: Configure minimum interval on parser level
+- **StandardParser function**: Get a copy of the standard parser for customization
+
 ### Planned for v2
 - Context-aware Job interface with graceful shutdown support
 
@@ -72,7 +80,7 @@ This fork includes all features from robfig/cron v3 plus:
 | Scheduling algorithm | O(n) sort | O(log n) min-heap |
 | Custom time source | No | WithClock option |
 | Step range validation | No | Yes |
-| @every minimum duration | No | 1 second |
+| @every minimum duration | No | 1 second (configurable) |
 | Timezone validation | No | Yes |
 | Input length limits | No | Yes |
 | Timeout wrapper | No | Yes |

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -135,7 +135,11 @@ c.AddFunc("@every 100ms", myFunc) // Allowed, but could overwhelm system
 **After (netresearch/go-cron):**
 ```go
 _, err := c.AddFunc("@every 100ms", myFunc)
-// err: "@every duration must be at least 1 second"
+// err: "@every duration must be at least 1s: @every 100ms"
+
+// To allow sub-second intervals (e.g., for testing):
+c := cron.New(cron.WithMinEveryInterval(0))
+c.AddFunc("@every 100ms", myFunc) // Now allowed
 ```
 
 #### Input Length Limits

--- a/parser_test.go
+++ b/parser_test.go
@@ -138,10 +138,10 @@ func TestParseScheduleErrors(t *testing.T) {
 		{"* * * *", "expected 5 to 6 fields"},
 		{"", "empty spec string"},
 		// @every minimum duration validation (must be >= 1 second)
-		{"@every 500ms", "@every duration must be at least 1 second"},
-		{"@every 100ms", "@every duration must be at least 1 second"},
-		{"@every 999ms", "@every duration must be at least 1 second"},
-		{"@every 1ns", "@every duration must be at least 1 second"},
+		{"@every 500ms", "@every duration must be at least 1s"},
+		{"@every 100ms", "@every duration must be at least 1s"},
+		{"@every 999ms", "@every duration must be at least 1s"},
+		{"@every 1ns", "@every duration must be at least 1s"},
 	}
 	for _, c := range tests {
 		actual, err := secondParser.Parse(c.expr)


### PR DESCRIPTION
## Summary
- Add `WithMinEveryInterval` option to configure minimum duration for `@every` expressions
- Add `EveryWithMin` function for creating schedules with custom minimum intervals
- Add `Parser.WithMinEveryInterval` for parser-level configuration
- Add `StandardParser()` to get a copy of the standard parser for customization

## Use Cases
- **Testing**: `WithMinEveryInterval(0)` allows sub-second intervals
- **Rate limiting**: `WithMinEveryInterval(time.Minute)` enforces longer minimums

## Test Plan
- [x] Unit tests for `EveryWithMin` function
- [x] Unit tests for `WithMinEveryInterval` option
- [x] Unit tests for `Parser.WithMinEveryInterval`
- [x] Unit tests for `StandardParser`
- [x] Backward compatibility tests for `Every()`
- [x] Sub-second execution test with fake clock