### PR TITLE
docs: clarify panic recovery is not enabled by default

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -175,7 +175,7 @@ A Cron runner may be configured with a chain of job wrappers to add
 cross-cutting functionality to all submitted jobs. For example, they may be used
 to achieve the following effects:
 
-  - Recover any panics from jobs (activated by default)
+  - Recover any panics from jobs
   - Delay a job's execution if the previous run hasn't completed yet
   - Skip a job's execution if the previous run hasn't completed yet
   - Log each job's invocations
@@ -183,6 +183,7 @@ to achieve the following effects:
 Install wrappers for all jobs added to a cron using the `cron.WithChain` option:
 
 	cron.New(cron.WithChain(
+		cron.Recover(logger),  // Recommended: recover panics to prevent crashes
 		cron.SkipIfStillRunning(logger),
 	))
 


### PR DESCRIPTION
## Summary

- Removes misleading "(activated by default)" from panic recovery description in doc.go
- Adds explicit `cron.Recover(logger)` example with recommendation comment
- Aligns documentation with actual behavior where users must explicitly opt-in to panic recovery

## Changes

The documentation previously implied that panic recovery was enabled by default, which could lead users to skip adding the `Recover` wrapper and have their cron schedulers crash on job panics.

Fixes #106

## Test Plan

- [x] Documentation change only - no code behavior changes
- [x] Verified existing tests pass with `go test -race ./...`