### PR TITLE
feat: add configurable max search years for schedule matching (#108)

### DIFF
--- a/option.go
+++ b/option.go
@@ -122,6 +122,34 @@ func WithMinEveryInterval(d time.Duration) Option {
 	}
 }
 
+// WithMaxSearchYears configures the maximum years into the future that schedule
+// matching will search before giving up. This prevents infinite loops for
+// unsatisfiable schedules (e.g., Feb 30).
+//
+// The default is 5 years. Values <= 0 will use the default.
+//
+// Use cases:
+//   - Shorter limits for faster failure detection: WithMaxSearchYears(1)
+//   - Longer limits for rare schedules: WithMaxSearchYears(10)
+//
+// Note: This option replaces the current parser. If you need custom parser options
+// along with a custom max search years, use WithParser with a manually configured parser:
+//
+//	p := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor).
+//	    WithMaxSearchYears(10)
+//	c := cron.New(cron.WithParser(p))
+//
+// Example:
+//
+//	// Allow searching up to 10 years for rare schedules
+//	c := cron.New(cron.WithMaxSearchYears(10))
+//	c.AddFunc("0 0 13 * 5", func() { ... }) // Friday the 13th
+func WithMaxSearchYears(years int) Option {
+	return func(c *Cron) {
+		c.parser = StandardParser().WithMaxSearchYears(years)
+	}
+}
+
 // WithMaxEntries limits the maximum number of entries that can be added to the Cron.
 // When the limit is reached:
 //   - AddFunc and AddJob return ErrMaxEntriesReached

--- a/option_test.go
+++ b/option_test.go
@@ -253,3 +253,27 @@ func TestStandardParser(t *testing.T) {
 		t.Error("standardParser should still enforce 1s minimum")
 	}
 }
+
+func TestWithMaxSearchYears(t *testing.T) {
+	// Test that WithMaxSearchYears creates a cron with the configured parser
+	c := New(WithMaxSearchYears(10))
+
+	// Parse an impossible schedule and verify it uses the configured search years
+	// We can't directly test the internal parser, but we can test the behavior
+	id, err := c.AddFunc("0 0 30 2 *", func() {}) // Feb 30 - impossible
+	if err != nil {
+		t.Fatalf("AddFunc() unexpected error: %v", err)
+	}
+
+	entry := c.Entry(id)
+	// The schedule should exist but Next() should return zero time
+	if entry.Schedule == nil {
+		t.Fatal("Expected entry to have a schedule")
+	}
+
+	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	next := entry.Schedule.Next(now)
+	if !next.IsZero() {
+		t.Errorf("Next() for impossible schedule should return zero time, got %v", next)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `WithMaxSearchYears` option at both parser and cron levels
- Allows configuring how many years into the future schedule matching searches
- Zero value falls back to default (5 years) for backward compatibility

## Changes
- Add `MaxSearchYears` field to `SpecSchedule` struct
- Add `maxSearchYears` field to `Parser` struct with `WithMaxSearchYears` method
- Add `WithMaxSearchYears` option for Cron-level configuration
- Rename `scheduleSearchYears` constant to `defaultSearchYears` for clarity

## Use Cases
- Shorter limits for faster failure detection: `WithMaxSearchYears(1)`
- Longer limits for rare schedules: `WithMaxSearchYears(10)`

## Test plan
- [x] All existing tests pass
- [x] New tests for parser-level `WithMaxSearchYears`
- [x] New tests for cron-level `WithMaxSearchYears`
- [x] Race detector passes
- [x] Code review with Zen passed

Closes #108