### PR TITLE
fix: address code review issues (#136-#165)

### DIFF
--- a/constantdelay.go
+++ b/constantdelay.go
@@ -54,7 +54,14 @@ func EveryWithMin(duration, minInterval time.Duration) ConstantDelaySchedule {
 // Next returns the next time this should be run.
 // For delays of 1 second or more, this rounds to the next second boundary.
 // For sub-second delays, no rounding is performed.
+//
+// If the delay is zero or negative (invalid), returns t + 1 second as a
+// safe fallback to prevent CPU spin loops in the scheduler.
 func (schedule ConstantDelaySchedule) Next(t time.Time) time.Time {
+	// Defensive: prevent CPU spin loop if delay is zero or negative
+	if schedule.Delay <= 0 {
+		return t.Add(time.Second)
+	}
 	// For sub-second intervals, don't round to second boundary
 	if schedule.Delay < time.Second {
 		return t.Add(schedule.Delay)

--- a/doc.go
+++ b/doc.go
@@ -309,13 +309,25 @@ Example of a cancellable job pattern:
 		}
 	}
 
-# Thread safety
+# Thread Safety
 
-Since the Cron service runs concurrently with the calling code, some amount of
-care must be taken to ensure proper synchronization.
+Cron is safe for concurrent use. Multiple goroutines may call methods on a Cron
+instance simultaneously without external synchronization.
 
-All cron methods are designed to be correctly synchronized as long as the caller
-ensures that invocations have a clear happens-before ordering between them.
+Specific guarantees:
+  - AddJob/AddFunc: Safe to call while scheduler is running
+  - Remove: Safe to call while scheduler is running
+  - Entries: Returns a snapshot; safe but may be stale
+  - Start/Stop: Safe to call multiple times (idempotent)
+  - Entry: Safe to call; returns copy of entry data
+
+Job Execution:
+  - Jobs may run concurrently by default
+  - Use SkipIfStillRunning or DelayIfStillRunning for serialization
+  - Jobs should not block indefinitely (use Timeout or TimeoutWithContext)
+
+The scheduler uses an internal channel-based synchronization model. All
+operations that modify scheduler state are serialized through this channel.
 
 # Logging
 

--- a/heap.go
+++ b/heap.go
@@ -40,9 +40,14 @@ func (h *entryHeap) Push(x any) {
 }
 
 // Pop removes and returns the minimum entry (earliest Next time).
+// Returns nil if the heap is empty (defensive check for direct calls
+// bypassing container/heap which already checks Len() > 0).
 func (h *entryHeap) Pop() any {
 	old := *h
 	n := len(old)
+	if n == 0 {
+		return nil // defensive: prevent panic on empty heap
+	}
 	entry := old[n-1]
 	old[n-1] = nil       // avoid memory leak
 	entry.heapIndex = -1 // mark as removed

--- a/logger.go
+++ b/logger.go
@@ -19,42 +19,42 @@ var DiscardLogger = PrintfLogger(log.New(io.Discard, "", 0))
 // can be plugged in. It is a subset of the github.com/go-logr/logr interface.
 type Logger interface {
 	// Info logs routine messages about cron's operation.
-	Info(msg string, keysAndValues ...interface{})
+	Info(msg string, keysAndValues ...any)
 	// Error logs an error condition.
-	Error(err error, msg string, keysAndValues ...interface{})
+	Error(err error, msg string, keysAndValues ...any)
 }
 
 // PrintfLogger wraps a Printf-based logger (such as the standard library "log")
 // into an implementation of the Logger interface which logs errors only.
-func PrintfLogger(l interface{ Printf(string, ...interface{}) }) Logger {
+func PrintfLogger(l interface{ Printf(string, ...any) }) Logger {
 	return printfLogger{l, false}
 }
 
 // VerbosePrintfLogger wraps a Printf-based logger (such as the standard library
 // "log") into an implementation of the Logger interface which logs everything.
-func VerbosePrintfLogger(l interface{ Printf(string, ...interface{}) }) Logger {
+func VerbosePrintfLogger(l interface{ Printf(string, ...any) }) Logger {
 	return printfLogger{l, true}
 }
 
 type printfLogger struct {
-	logger  interface{ Printf(string, ...interface{}) }
+	logger  interface{ Printf(string, ...any) }
 	logInfo bool
 }
 
-func (pl printfLogger) Info(msg string, keysAndValues ...interface{}) {
+func (pl printfLogger) Info(msg string, keysAndValues ...any) {
 	if pl.logInfo {
 		keysAndValues = formatTimes(keysAndValues)
 		pl.logger.Printf(
 			formatString(len(keysAndValues)),
-			append([]interface{}{msg}, keysAndValues...)...)
+			append([]any{msg}, keysAndValues...)...)
 	}
 }
 
-func (pl printfLogger) Error(err error, msg string, keysAndValues ...interface{}) {
+func (pl printfLogger) Error(err error, msg string, keysAndValues ...any) {
 	keysAndValues = formatTimes(keysAndValues)
 	pl.logger.Printf(
 		formatString(len(keysAndValues)+2),
-		append([]interface{}{msg, "error", err}, keysAndValues...)...)
+		append([]any{msg, "error", err}, keysAndValues...)...)
 }
 
 // formatString returns a logfmt-like format string for the number of
@@ -75,8 +75,8 @@ func formatString(numKeysAndValues int) string {
 }
 
 // formatTimes formats any time.Time values as RFC3339.
-func formatTimes(keysAndValues []interface{}) []interface{} {
-	formattedArgs := make([]interface{}, 0, len(keysAndValues))
+func formatTimes(keysAndValues []any) []any {
+	formattedArgs := make([]any, 0, len(keysAndValues))
 	for _, arg := range keysAndValues {
 		if t, ok := arg.(time.Time); ok {
 			arg = t.Format(time.RFC3339)
@@ -102,11 +102,11 @@ func NewSlogLogger(l *slog.Logger) *SlogLogger {
 }
 
 // Info logs routine messages about cron's operation using slog.
-func (s *SlogLogger) Info(msg string, keysAndValues ...interface{}) {
+func (s *SlogLogger) Info(msg string, keysAndValues ...any) {
 	s.logger.Info(msg, keysAndValues...)
 }
 
 // Error logs an error condition using slog.
-func (s *SlogLogger) Error(err error, msg string, keysAndValues ...interface{}) {
-	s.logger.Error(msg, append([]interface{}{"error", err}, keysAndValues...)...)
+func (s *SlogLogger) Error(err error, msg string, keysAndValues ...any) {
+	s.logger.Error(msg, append([]any{"error", err}, keysAndValues...)...)
 }


### PR DESCRIPTION
## Summary

This PR addresses multiple issues identified during code review (issues #136-#165). The changes focus on bug fixes, API improvements, and documentation enhancements while maintaining backward compatibility.

### Changes Implemented

#### Bug Fixes
- **#144**: `heap.Pop` defensive nil check for empty heap
- **#156**: `constantdelay.Next` handles zero/negative duration safely (returns t+1s to prevent CPU spin)
- **#137**: `TimeoutWithContext` cleanup timeout (5s grace period) to prevent indefinite blocking

#### API Improvements
- **#136**: Add jitter (±10%) to `RetryWithBackoff` to prevent thundering herd
- **#138**: Modernize Logger interface to use `any` instead of `interface{}` (Go 1.18+)
- **#141**: Add `PanicWithStack` type for preserved stack traces across retry/timeout wrappers
- **#165**: `Recover` wrapper logs `panic_type` for typed error handling

#### Documentation
- **#152**: Add `ExampleTimeoutWithContext` godoc example
- **#161**: Explicit thread safety guarantees in doc.go

### Files Modified
- `chain.go`: TimeoutWithContext cleanup timeout, Recover panic_type logging
- `constantdelay.go`: Zero/negative duration handling
- `doc.go`: Thread safety documentation
- `example_test.go`: TimeoutWithContext example
- `heap.go`: Defensive nil check in Pop()
- `logger.go`: interface{} → any modernization
- `retry.go`: PanicWithStack type, jitter in backoff calculation

### Deferred Issues
The following issues have been labeled for future releases:
- **v1.1**: #139, #146, #151, #155, #158, #159, #162 (enhancements)
- **v2.0**: #140, #150 (breaking API changes)

### Testing
- All tests pass with race detector: `go test -race ./...`
- Examples compile and run correctly
- Benchmarks unchanged

## Test plan
- [x] Run `go test -race ./...`
- [x] Verify examples compile
- [x] Check backward compatibility
- [x] Review panic handling across wrappers

Closes #136, #137, #138, #141, #144, #152, #156, #161, #165