### PR TITLE
feat: add MustNewParser for forward compatibility with v2.0

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -138,6 +138,34 @@ func NewParser(options ParseOption) Parser {
 	return p
 }
 
+// MustNewParser is like TryNewParser but panics if the options are invalid.
+// This follows the Go convention of Must* functions for cases where failure
+// indicates a programming error rather than a runtime condition.
+//
+// Use MustNewParser when:
+//   - Parser options are hardcoded constants
+//   - Invalid configuration is a bug that should fail fast
+//
+// Use TryNewParser when:
+//   - Parser options come from config files, environment, or user input
+//   - You want to handle configuration errors gracefully
+//
+// Note: In v2.0, NewParser will return (Parser, error) and MustNewParser
+// will be the only panicking variant. Using MustNewParser now ensures
+// forward compatibility with v2.0.
+//
+// Example:
+//
+//	// Panics if options are invalid (hardcoded, so invalid = bug)
+//	var parser = cron.MustNewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+func MustNewParser(options ParseOption) Parser {
+	p, err := TryNewParser(options)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
 // WithMinEveryInterval returns a new Parser with the specified minimum interval
 // for @every expressions. This allows overriding the default 1-second minimum.
 //

--- a/parser_test.go
+++ b/parser_test.go
@@ -491,6 +491,26 @@ func TestTryNewParser(t *testing.T) {
 	})
 }
 
+func TestMustNewParser(t *testing.T) {
+	t.Run("panics with invalid options", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("MustNewParser(0) should panic with no fields configured")
+			}
+		}()
+		MustNewParser(0)
+	})
+
+	t.Run("succeeds with valid options", func(t *testing.T) {
+		// Should not panic
+		parser := MustNewParser(Minute | Hour | Dom | Month | Dow)
+		_, err := parser.Parse("0 0 * * *")
+		if err != nil {
+			t.Errorf("parser should work, got: %v", err)
+		}
+	})
+}
+
 func every5min(loc *time.Location) *SpecSchedule {
 	return &SpecSchedule{1 << 0, 1 << 5, all(hours), all(dom), all(months), all(dow), loc, 0}
 }


### PR DESCRIPTION
## Summary

Add `MustNewParser` as an explicit panicking variant following Go's `Must*` convention. This prepares users for v2.0 API changes.

## v2.0 Migration Path

| Function | v1.x | v2.0 |
|----------|------|------|
| `TryNewParser` | Returns `(Parser, error)` | Same |
| `MustNewParser` | Panics on error | Same |
| `NewParser` | Panics on error | **Returns `(Parser, error)`** |

Users can start migrating to `MustNewParser` now for hardcoded configs, ensuring a smooth transition.

## Usage

```go
// For hardcoded options (invalid = bug) - use MustNewParser
var parser = cron.MustNewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)

// For runtime config - use TryNewParser
parser, err := cron.TryNewParser(opts)
```

## Test plan

- [x] Test `MustNewParser` panics with invalid options
- [x] Test `MustNewParser` succeeds with valid options
- [x] All existing tests pass