### PR TITLE
docs: mark NewParser as deprecated for v2.0 migration

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -111,11 +111,12 @@ func TryNewParser(options ParseOption) (Parser, error) {
 
 // NewParser creates a Parser with custom options.
 //
+// Deprecated: NewParser will change to return (Parser, error) in v2.0.
+// Use [MustNewParser] for panic-on-error behavior (forward compatible),
+// or [TryNewParser] for explicit error handling.
+//
 // It panics if more than one Optional is given, since it would be impossible to
 // correctly infer which optional is provided or missing in general.
-//
-// For runtime configuration where errors should be handled gracefully,
-// use TryNewParser instead.
 //
 // Examples
 //


### PR DESCRIPTION
## Summary

Add `Deprecated:` godoc comment to `NewParser` to guide users toward the new API.

## Change

```go
// Deprecated: NewParser will change to return (Parser, error) in v2.0.
// Use [MustNewParser] for panic-on-error behavior (forward compatible),
// or [TryNewParser] for explicit error handling.
func NewParser(options ParseOption) Parser
```

## Effect

- IDEs (VS Code, GoLand) will show strikethrough on `NewParser`
- `staticcheck` and `gopls` will warn about deprecated usage
- `go doc` shows the deprecation notice
- Zero runtime overhead