### PR TITLE
feat: add WithSecondOptional for flexible cron expressions

### DIFF
--- a/option.go
+++ b/option.go
@@ -23,6 +23,26 @@ func WithSeconds() Option {
 	))
 }
 
+// WithSecondOptional overrides the parser used for interpreting job schedules to
+// accept an optional seconds field as the first one. When provided, expressions can
+// have either 5 fields (standard) or 6 fields (with seconds). If 5 fields are given,
+// the seconds field defaults to 0.
+//
+// This is useful when you want to support both standard 5-field cron expressions
+// and extended 6-field expressions with seconds precision in the same cron instance.
+//
+// Examples:
+//
+//	c := cron.New(cron.WithSecondOptional())
+//	c.AddFunc("* * * * *", job)        // 5 fields: runs every minute at :00 seconds
+//	c.AddFunc("30 * * * * *", job)     // 6 fields: runs every minute at :30 seconds
+//	c.AddFunc("*/10 * * * * *", job)   // 6 fields: runs every 10 seconds
+func WithSecondOptional() Option {
+	return WithParser(NewParser(
+		SecondOptional | Minute | Hour | Dom | Month | Dow | Descriptor,
+	))
+}
+
 // WithParser overrides the parser used for interpreting job schedules.
 func WithParser(p ScheduleParser) Option {
 	return func(c *Cron) {

--- a/parser.go
+++ b/parser.go
@@ -247,6 +247,32 @@ func (p Parser) WithCache() Parser {
 	return p
 }
 
+// WithSecondOptional returns a new Parser configured to accept an optional seconds
+// field as the first field. This allows the parser to accept both 5-field (standard)
+// and 6-field (with seconds) expressions.
+//
+// When 5 fields are provided, the seconds field defaults to 0.
+// When 6 fields are provided, the first field is interpreted as seconds.
+//
+// This method enables composable parser configuration when you need both
+// SecondOptional and other parser customizations (like WithMinEveryInterval or
+// WithMaxSearchYears).
+//
+// Example:
+//
+//	// Parser accepting optional seconds with custom minimum @every interval
+//	p := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor).
+//	    WithSecondOptional().
+//	    WithMinEveryInterval(100 * time.Millisecond)
+//
+//	// Both expressions are valid:
+//	sched1, _ := p.Parse("* * * * *")       // 5 fields, seconds=0
+//	sched2, _ := p.Parse("30 * * * * *")    // 6 fields, seconds=30
+func (p Parser) WithSecondOptional() Parser {
+	p.options |= SecondOptional | Minute | Hour | Dom | Month | Dow
+	return p
+}
+
 // MaxSpecLength is the maximum allowed length for a cron spec string.
 // This limit prevents potential resource exhaustion from extremely long inputs.
 const MaxSpecLength = 1024


### PR DESCRIPTION
## Summary

Add two new APIs for optional seconds support:

1. **`WithSecondOptional()` Cron option** - Simple setup for cron instances that need to accept both 5-field (standard) and 6-field (with seconds) expressions
2. **`Parser.WithSecondOptional()` builder method** - Composable parser configuration enabling chaining with `WithMinEveryInterval`, `WithMaxSearchYears`, etc.

## Behavior

- When 5 fields are provided, seconds defaults to 0
- When 6 fields are provided, the first field is interpreted as seconds

## API Examples

```go
// Cron Option - simple setup
c := cron.New(cron.WithSecondOptional())
c.AddFunc("* * * * *", job)        // 5 fields, seconds=0
c.AddFunc("30 * * * * *", job)     // 6 fields, seconds=30

// Parser builder - composable configuration
p := cron.NewParser(cron.Minute|cron.Hour|cron.Dom|cron.Month|cron.Dow|cron.Descriptor).
    WithSecondOptional().
    WithMinEveryInterval(0)
```

## Test plan

- [x] Tests for `WithSecondOptional()` Cron option with 5 and 6 field expressions
- [x] Tests for timezone handling with optional seconds
- [x] Tests for `Parser.WithSecondOptional()` builder method
- [x] Tests for method chaining with other parser options
- [x] Tests for invalid field counts (4 fields, 7 fields)
- [x] Full test suite passes

Closes #220