### PR TITLE
feat: add Schedule.Prev() method for previous execution time

### DIFF
--- a/constantdelay.go
+++ b/constantdelay.go
@@ -69,3 +69,19 @@ func (schedule ConstantDelaySchedule) Next(t time.Time) time.Time {
 	// For second+ intervals, round to the second
 	return t.Add(schedule.Delay - time.Duration(t.Nanosecond())*time.Nanosecond)
 }
+
+// Prev returns the previous activation time, earlier than the given time.
+// For ConstantDelaySchedule, this simply subtracts the delay.
+// If the delay is zero or negative (invalid), returns t - 1 second as a safe fallback.
+func (schedule ConstantDelaySchedule) Prev(t time.Time) time.Time {
+	// Defensive: prevent invalid results if delay is zero or negative
+	if schedule.Delay <= 0 {
+		return t.Add(-time.Second)
+	}
+	// For sub-second intervals, don't round to second boundary
+	if schedule.Delay < time.Second {
+		return t.Add(-schedule.Delay)
+	}
+	// For second+ intervals, round to the second boundary
+	return t.Add(-schedule.Delay + time.Duration(t.Nanosecond())*time.Nanosecond)
+}

--- a/cron.go
+++ b/cron.go
@@ -107,6 +107,11 @@ type Schedule interface {
 	// Next returns the next activation time, later than the given time.
 	// Next is invoked initially, and then each time the job is run.
 	Next(time.Time) time.Time
+
+	// Prev returns the previous activation time, earlier than the given time.
+	// This is useful for detecting missed executions or determining the last
+	// scheduled run time. Returns zero time if no previous time can be found.
+	Prev(time.Time) time.Time
 }
 
 // EntryID identifies an entry within a Cron instance.

--- a/cron_test.go
+++ b/cron_test.go
@@ -635,6 +635,10 @@ func (*ZeroSchedule) Next(time.Time) time.Time {
 	return time.Time{}
 }
 
+func (*ZeroSchedule) Prev(time.Time) time.Time {
+	return time.Time{}
+}
+
 // Tests that job without time does not run
 func TestJobWithZeroTimeDoesNotRun(t *testing.T) {
 	cron := newWithSeconds()

--- a/stress_test.go
+++ b/stress_test.go
@@ -199,6 +199,12 @@ func (s *slowSchedule) Next(t time.Time) time.Time {
 	return t.Add(time.Hour)
 }
 
+func (s *slowSchedule) Prev(t time.Time) time.Time {
+	// Simulate expensive calculation
+	time.Sleep(s.delay)
+	return t.Add(-time.Hour)
+}
+
 // TestSlowScheduleNext tests behavior with slow Schedule.Next() implementations.
 // Note: Schedule.Next() panics are NOT currently handled by the scheduler and will
 // crash the run loop. This is a known limitation - schedules must not panic.


### PR DESCRIPTION
## Summary
- Add `Prev()` method to the `Schedule` interface that calculates the previous scheduled execution time before a given time
- Implement `SpecSchedule.Prev()` mirroring the `Next()` algorithm but decrementing fields with proper wrap-around handling
- Implement `ConstantDelaySchedule.Prev()` by subtracting the delay interval
- Both implementations respect timezone settings and `MaxSearchYears` limits

## Use Cases
- **Detecting missed executions**: Compare `Prev(now)` with last known run time to find gaps
- **Audit logging**: Determine when a job should have last run
- **Monitoring**: Calculate expected vs actual execution times
- **Schedule validation**: Verify schedule configurations work as expected

## Example Usage
```go
schedule, _ := cron.ParseStandard("0 9 * * MON-FRI")
now := time.Now()

// Find previous execution
prev := schedule.Prev(now)
fmt.Printf("Previous run: %v\n", prev)

// Detect missed executions
lastRun := getLastRunFromDB()
if schedule.Prev(now).After(lastRun) {
    log.Warn("Missed scheduled executions detected")
}
```

## Test plan
- [x] `TestPrev`: Table-driven tests for various schedule patterns
- [x] `TestPrevWithTz`: Timezone handling verification  
- [x] `TestPrevUnsatisfiable`: Impossible schedules (Feb 30) return zero time
- [x] `TestPrevAndNextSymmetry`: Verifies `Prev(Next(t)+1s) == Next(t)` 
- [x] `TestConstantDelayPrev`: Basic constant delay tests
- [x] `TestConstantDelayPrevBoundaries`: Edge cases for nanosecond handling
- [x] `TestConstantDelayPrevAndNextSymmetry`: Symmetry verification
- [x] Example tests demonstrating common use cases

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)