### PR TITLE
feat: add jitter wrappers to prevent thundering herd

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -251,6 +251,7 @@ to achieve the following effects:
   - Delay a job's execution if the previous run hasn't completed yet
   - Skip a job's execution if the previous run hasn't completed yet
   - Log each job's invocations
+  - Add random delay (jitter) to prevent thundering herd
 
 Install wrappers for all jobs added to a cron using the `cron.WithChain` option:
 
@@ -312,6 +313,7 @@ Available Wrappers:
   - TimeoutWithContext: True cancellation via context
   - RetryWithBackoff: Retry panicking jobs with exponential backoff
   - CircuitBreaker: Stop execution after consecutive failures
+  - Jitter: Add random delay to prevent thundering herd
 
 # Timeout Wrapper Caveats
 


### PR DESCRIPTION
## Summary

Adds jitter support to prevent thundering herd problems when many jobs are scheduled at the same time.

Closes #227

- Adds `Jitter(maxJitter time.Duration)` JobWrapper - adds random delay in [0, maxJitter)
- Adds `JitterWithLogger(logger, maxJitter)` - same with delay logging for observability
- Zero or negative maxJitter disables jitter (no-op behavior)
- Uses `math/rand/v2` from Go stdlib (no external dependency)

## Implementation Approach

This implements jitter using the existing **JobWrapper pattern** rather than the upstream approach (robfig/cron#525) that adds 4 new methods to the Cron type. Benefits:

- **Composable**: Works seamlessly with other wrappers (Recover, SkipIfStillRunning, etc.)
- **Consistent API**: Follows established patterns in this codebase
- **Flexible**: Can be applied globally via `WithChain` or per-job via `NewChain().Then()`
- **Zero overhead**: Disabled jitter adds no delay

## Usage Examples

```go
// Global jitter for all jobs
c := cron.New(cron.WithChain(
    cron.Recover(logger),
    cron.Jitter(30 * time.Second),
))

// Per-job jitter
job := cron.NewChain(cron.Jitter(5 * time.Second)).Then(myJob)
c.Schedule(cron.Every(time.Hour), job)
```

## Test plan

- [x] Tests verify delay is within expected range
- [x] Tests verify zero/negative maxJitter disables jitter
- [x] Tests verify uniform distribution across range
- [x] Tests verify composition with other wrappers
- [x] Tests verify logging behavior
- [x] All existing tests pass
- [x] Pre-commit hooks pass (lint, build, security scan)