### PR TITLE
refactor: use optional ScheduleWithPrev interface for backward compatibility

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -107,10 +107,24 @@ type Schedule interface {
 	// Next returns the next activation time, later than the given time.
 	// Next is invoked initially, and then each time the job is run.
 	Next(time.Time) time.Time
+}
 
+// ScheduleWithPrev is an optional interface that schedules can implement
+// to support backward time traversal. This is useful for detecting missed
+// executions or determining the last scheduled run time.
+//
+// Built-in schedules (SpecSchedule, ConstantDelaySchedule) implement this
+// interface. Custom Schedule implementations may optionally implement it.
+//
+// Use type assertion to check for support:
+//
+//	if sp, ok := schedule.(ScheduleWithPrev); ok {
+//	    prev := sp.Prev(time.Now())
+//	}
+type ScheduleWithPrev interface {
+	Schedule
 	// Prev returns the previous activation time, earlier than the given time.
-	// This is useful for detecting missed executions or determining the last
-	// scheduled run time. Returns zero time if no previous time can be found.
+	// Returns zero time if no previous time can be found.
 	Prev(time.Time) time.Time
 }
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -323,6 +323,36 @@ activation time, later than the given time.
 
 ---
 
+### ScheduleWithPrev
+
+```go
+type ScheduleWithPrev interface {
+    Schedule
+    Prev(time.Time) time.Time
+}
+```
+
+ScheduleWithPrev is an optional interface that schedules can implement to support
+backward time traversal. This is useful for detecting missed executions or
+determining the last scheduled run time.
+
+Built-in schedules (`SpecSchedule`, `ConstantDelaySchedule`) implement this interface.
+Custom Schedule implementations may optionally implement it.
+
+**Usage:**
+
+```go
+schedule, _ := cron.ParseStandard("0 9 * * *")
+
+// Type assert to access Prev()
+if sp, ok := schedule.(cron.ScheduleWithPrev); ok {
+    prev := sp.Prev(time.Now())
+    fmt.Println("Last scheduled run:", prev)
+}
+```
+
+---
+
 ### ScheduleParser
 
 ```go

--- a/docs/PROJECT_INDEX.md
+++ b/docs/PROJECT_INDEX.md
@@ -187,6 +187,16 @@ type Schedule interface {
 }
 ```
 
+#### `ScheduleWithPrev`
+```go
+type ScheduleWithPrev interface {
+    Schedule
+    Prev(time.Time) time.Time
+}
+```
+
+Optional interface for backward time traversal. Built-in schedules implement this.
+
 #### `ScheduleParser`
 ```go
 type ScheduleParser interface {

--- a/introspect.go
+++ b/introspect.go
@@ -153,7 +153,7 @@ func CountWithLimit(schedule Schedule, start, end time.Time, limit int) int {
 // For minute-level schedules, seconds and nanoseconds in t are ignored.
 // For second-level schedules, nanoseconds are ignored.
 //
-// Returns false if schedule is nil.
+// Returns false if schedule is nil or doesn't implement ScheduleWithPrev.
 //
 // Example:
 //
@@ -166,13 +166,19 @@ func Matches(schedule Schedule, t time.Time) bool {
 		return false
 	}
 
+	// Matches requires Prev() support
+	sp, ok := schedule.(ScheduleWithPrev)
+	if !ok {
+		return false
+	}
+
 	// Use Prev to find the most recent scheduled time at or before t,
 	// then check if it equals t (ignoring sub-second precision).
 	//
 	// We need to check from a point slightly after t to catch exact matches.
 	// Add 1 second to ensure we catch the current time if it's a match.
 	checkTime := t.Add(time.Second)
-	prev := schedule.Prev(checkTime)
+	prev := sp.Prev(checkTime)
 
 	if prev.IsZero() {
 		return false

--- a/spec_test.go
+++ b/spec_test.go
@@ -559,7 +559,7 @@ func TestPrev(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			actual := sched.Prev(getTime(c.time))
+			actual := sched.(ScheduleWithPrev).Prev(getTime(c.time))
 			expected := getTime(c.expected)
 			if !actual.Equal(expected) {
 				t.Errorf("%s, \"%s\": (expected) %v != %v (actual)", c.time, c.spec, expected, actual)
@@ -587,7 +587,7 @@ func TestPrevWithTz(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			actual := sched.Prev(getTimeTZ(c.time))
+			actual := sched.(ScheduleWithPrev).Prev(getTimeTZ(c.time))
 			expected := getTimeTZ(c.expected)
 			if !actual.Equal(expected) {
 				t.Errorf("%s, \"%s\": (expected) %v != %v (actual)", c.time, c.spec, expected, actual)
@@ -603,7 +603,7 @@ func TestPrevUnsatisfiable(t *testing.T) {
 		t.Fatal(err)
 	}
 	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
-	result := sched.Prev(now)
+	result := sched.(ScheduleWithPrev).Prev(now)
 	if !result.IsZero() {
 		t.Errorf("Expected zero time for unsatisfiable schedule, got %v", result)
 	}
@@ -640,7 +640,7 @@ func TestPrevAndNextSymmetry(t *testing.T) {
 			}
 
 			// Prev from just after the scheduled time should return the scheduled time
-			prevTime := sched.Prev(scheduledTime.Add(time.Second))
+			prevTime := sched.(ScheduleWithPrev).Prev(scheduledTime.Add(time.Second))
 			if !prevTime.Equal(scheduledTime) {
 				t.Errorf("Prev(Next(t)+1s) = %v, want %v", prevTime, scheduledTime)
 			}

--- a/year_test.go
+++ b/year_test.go
@@ -269,7 +269,7 @@ func TestYearFieldSchedulePrev(t *testing.T) {
 				t.Fatalf("Parse(%q) error = %v", tt.spec, err)
 			}
 
-			prev := schedule.Prev(tt.from)
+			prev := schedule.(ScheduleWithPrev).Prev(tt.from)
 			if tt.wantZero {
 				if !prev.IsZero() {
 					t.Errorf("Prev(%v) = %v, want zero time", tt.from, prev)
@@ -404,7 +404,7 @@ func TestYearFieldConcurrent(t *testing.T) {
 				if next.IsZero() {
 					t.Error("Next returned zero")
 				}
-				prev := schedule.Prev(from.Add(24 * time.Hour))
+				prev := schedule.(ScheduleWithPrev).Prev(from.Add(24 * time.Hour))
 				if prev.IsZero() {
 					t.Error("Prev returned zero")
 				}


### PR DESCRIPTION
## Summary

- Extract `Prev()` method from `Schedule` interface into optional `ScheduleWithPrev` interface
- Removes breaking change that would have required all custom `Schedule` implementations to add `Prev()`
- Built-in schedules (`SpecSchedule`, `ConstantDelaySchedule`) implement `ScheduleWithPrev`

## Motivation

The previous implementation added `Prev()` directly to the `Schedule` interface, which would have been a **breaking change** requiring a semver MAJOR version bump. This refactor uses Go's optional interface pattern (similar to `io.Reader` vs `io.ReaderAt`) to maintain backward compatibility.

## Usage

```go
schedule, _ := cron.ParseStandard("0 9 * * *")

// Type assert to access Prev()
if sp, ok := schedule.(cron.ScheduleWithPrev); ok {
    prev := sp.Prev(time.Now())
    fmt.Println("Last scheduled run:", prev)
}
```

## Changes

| File | Change |
|------|--------|
| cron.go | Create `ScheduleWithPrev` interface |
| introspect.go | Update `Matches()` to use type assertion |
| spec_test.go, year_test.go | Update test type assertions |
| example_test.go | Update examples to demonstrate pattern |
| docs/*.md | Add documentation for new interface |

## Test plan

- [x] All existing tests pass
- [x] Examples demonstrate correct usage pattern
- [x] Pre-push hooks pass (lint, vulncheck, tests)