### PR TITLE
fix: add PanicWithStack type alias for backward compatibility

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -76,6 +76,13 @@ type PanicError struct {
 	Stack []byte // Stack trace at point of panic
 }
 
+// PanicWithStack is a type alias for backward compatibility.
+//
+// Deprecated: Use PanicError instead. This alias will be removed in a future release.
+//
+//nolint:errname // This is intentionally a type alias for backward compat
+type PanicWithStack = PanicError
+
 // Error implements the error interface for PanicError.
 func (p *PanicError) Error() string {
 	return fmt.Sprintf("panic: %v", p.Value)

--- a/retry_test.go
+++ b/retry_test.go
@@ -627,3 +627,26 @@ func TestCircuitBreaker_IsOpenBoundary(t *testing.T) {
 			threshold+1, got)
 	}
 }
+
+// TestPanicWithStackAlias verifies the backward compatibility type alias.
+func TestPanicWithStackAlias(t *testing.T) {
+	// Create using the deprecated alias - this tests backward compatibility
+	p := PanicWithStack{Value: "test panic", Stack: []byte("stack trace")}
+
+	// Should have access to all PanicError methods
+	if p.Error() != "panic: test panic" {
+		t.Errorf("unexpected error message: %s", p.Error())
+	}
+
+	// Assignment to PanicError should work (same type)
+	pe := p
+	if pe.Value != "test panic" {
+		t.Errorf("unexpected value: %v", pe.Value)
+	}
+
+	// Assignment from PanicError to PanicWithStack should also work
+	pws := pe
+	if string(pws.Stack) != "stack trace" {
+		t.Errorf("unexpected stack: %s", pws.Stack)
+	}
+}


### PR DESCRIPTION
## Summary

- Add deprecated type alias `PanicWithStack = PanicError` to maintain backward compatibility
- Code using `PanicWithStack` type assertions will continue to work
- Added test to verify alias functionality

## Context

The code review identified that `PanicWithStack` was renamed to `PanicError`, which is a breaking change for consumers using type assertions. This PR adds a type alias to restore backward compatibility while encouraging migration to the new name.

## Test plan

- [x] Added `TestPanicWithStackAlias` to verify alias works correctly
- [x] All existing tests pass
- [x] Linter passes