### PR TITLE
ci: add Codecov integration and badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,34 @@ jobs:
           name: coverage-${{ matrix.platform }}
           path: coverage-${{ matrix.platform }}.out
 
+  codecov:
+    name: upload coverage
+    runs-on: ubuntu-latest
+    needs: unit
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          pattern: coverage-*
+          merge-multiple: true
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        with:
+          files: coverage-ubuntu-latest.out,coverage-windows-latest.out,coverage-macos-latest.out
+          fail_ci_if_error: false
+          verbose: true
+
   lint:
     name: golangci-lint
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/netresearch/go-cron.svg)](https://pkg.go.dev/github.com/netresearch/go-cron)
 [![CI](https://github.com/netresearch/go-cron/actions/workflows/ci.yml/badge.svg)](https://github.com/netresearch/go-cron/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/netresearch/go-cron/graph/badge.svg)](https://codecov.io/gh/netresearch/go-cron)
 [![CodeQL](https://img.shields.io/github/actions/workflow/status/netresearch/go-cron/codeql.yml?label=CodeQL)](https://github.com/netresearch/go-cron/security/code-scanning)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/netresearch/go-cron/badge)](https://scorecard.dev/viewer/?uri=github.com/netresearch/go-cron)
 [![Go Report Card](https://goreportcard.com/badge/github.com/netresearch/go-cron)](https://goreportcard.com/report/github.com/netresearch/go-cron)


### PR DESCRIPTION
## Summary

- Add Codecov upload job to CI workflow (downloads coverage artifacts and uploads to Codecov)
- Add Codecov badge to README

This enables code coverage tracking and visibility via Codecov.