### PR TITLE
ci: add codecov.yml with correct branch config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+# Codecov configuration
+# https://docs.codecov.com/docs/codecov-yaml
+
+codecov:
+  branch: main
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%


### PR DESCRIPTION
Sets the default branch to 'main' so Codecov dashboard shows coverage data correctly.