### PR TITLE
feat(spec): change DOM/DOW matching to AND logic by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The original `robfig/cron` has been unmaintained since 2020, accumulating 50+ op
 | TZ= parsing panics | Crashes on malformed input | Fixed (#554, #555) |
 | Chain decorators | `Entry.Run()` bypasses chains | Properly invokes wrappers (#551) |
 | DST spring-forward | Jobs silently skipped | Runs immediately (ISC behavior, #541) |
+| DOM/DOW logic | OR (confusing) | AND (logical, consistent) |
 | Go version | Stuck on 1.13 | Go 1.25+ with modern toolchain |
 
 ## Installation
@@ -148,6 +149,25 @@ cron.New(cron.WithParser(cron.NewParser(
     cron.Dom | cron.Month | cron.Dow | cron.Descriptor,
 )))
 ```
+
+### Day Matching (DOM/DOW)
+
+When both day-of-month and day-of-week are specified, **both must match** (AND logic). This is consistent with all other cron fields and enables useful patterns:
+
+```go
+// Last Friday of month (days 25-31 AND Friday)
+c.AddFunc("0 0 25-31 * FRI", lastFridayJob)
+
+// First Monday of month (days 1-7 AND Monday)
+c.AddFunc("0 0 1-7 * MON", firstMondayJob)
+
+// Friday the 13th
+c.AddFunc("0 0 13 * FRI", unluckyJob)
+```
+
+> [!NOTE]
+> This differs from robfig/cron which uses OR logic. For migration compatibility,
+> use the `DowOrDom` option or see [docs/MIGRATION.md](docs/MIGRATION.md).
 
 ## Timezone Support
 

--- a/doc.go
+++ b/doc.go
@@ -128,6 +128,29 @@ Question mark ( ? )
 Question mark may be used instead of '*' for leaving either day-of-month or
 day-of-week blank.
 
+# Day Matching (DOM/DOW)
+
+When both day-of-month and day-of-week are specified (non-wildcard), both must
+match (AND logic). This is consistent with how all other cron fields work.
+
+	0 0 25-31 * FRI   - Last Friday of month (days 25-31 AND Friday)
+	0 0 1-7 * MON     - First Monday of month (days 1-7 AND Monday)
+	0 0 13 * FRI      - Friday the 13th
+
+When either field is a wildcard (*), only the restricted field matters:
+
+	0 0 * * FRI       - Every Friday (any day-of-month that is Friday)
+	0 0 15 * *        - 15th of every month (any day-of-week)
+
+This differs from some cron implementations (Vixie cron, robfig/cron) that use
+OR logic when both fields are restricted. For legacy OR behavior:
+
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.DowOrDom)
+
+With DowOrDom enabled, the schedule matches if either field matches (OR logic):
+
+	0 0 15 * FRI      - 15th of month OR any Friday (legacy behavior)
+
 # Extended Syntax (Optional)
 
 The following extended syntax is available when enabled via parser options.

--- a/parser.go
+++ b/parser.go
@@ -35,6 +35,7 @@ const (
 	DowLast                                // Allow #L syntax in DOW (e.g., FRI#L for last Friday)
 	DomL                                   // Allow L syntax in DOM (e.g., L for last day, L-3 for 3rd last day)
 	DomW                                   // Allow W syntax in DOM (e.g., 15W for nearest weekday, LW for last weekday)
+	DowOrDom                               // Use legacy OR logic for DOW/DOM (default: AND)
 )
 
 // Extended is a convenience flag that enables all extended cron syntax options:
@@ -512,6 +513,7 @@ func (p Parser) parse(spec string) (Schedule, error) {
 		MaxSearchYears: p.maxSearchYears,
 		DomConstraints: domConstraints,
 		DowConstraints: dowConstraints,
+		DowOrDom:       p.options&DowOrDom > 0,
 	}, nil
 }
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -755,7 +755,7 @@ func TestStandardSpecSchedule(t *testing.T) {
 	}{
 		{
 			expr:     "5 * * * *",
-			expected: &SpecSchedule{1 << seconds.min, 1 << 5, all(hours), all(dom), all(months), allDowNormalized(), nil, time.Local, 0, nil, nil},
+			expected: &SpecSchedule{1 << seconds.min, 1 << 5, all(hours), all(dom), all(months), allDowNormalized(), nil, time.Local, 0, nil, nil, false},
 		},
 		{
 			expr:     "@every 5m",
@@ -987,15 +987,15 @@ func allDowNormalized() uint64 {
 }
 
 func every5min(loc *time.Location) *SpecSchedule {
-	return &SpecSchedule{1 << 0, 1 << 5, all(hours), all(dom), all(months), allDowNormalized(), nil, loc, 0, nil, nil}
+	return &SpecSchedule{1 << 0, 1 << 5, all(hours), all(dom), all(months), allDowNormalized(), nil, loc, 0, nil, nil, false}
 }
 
 func every5min5s(loc *time.Location) *SpecSchedule {
-	return &SpecSchedule{1 << 5, 1 << 5, all(hours), all(dom), all(months), allDowNormalized(), nil, loc, 0, nil, nil}
+	return &SpecSchedule{1 << 5, 1 << 5, all(hours), all(dom), all(months), allDowNormalized(), nil, loc, 0, nil, nil, false}
 }
 
 func midnight(loc *time.Location) *SpecSchedule {
-	return &SpecSchedule{1, 1, 1, all(dom), all(months), allDowNormalized(), nil, loc, 0, nil, nil}
+	return &SpecSchedule{1, 1, 1, all(dom), all(months), allDowNormalized(), nil, loc, 0, nil, nil, false}
 }
 
 func annual(loc *time.Location) *SpecSchedule {

--- a/year_test.go
+++ b/year_test.go
@@ -474,11 +474,12 @@ func TestSecondOptionalWithYear(t *testing.T) {
 		{
 			// 6 fields ending with number < 100 - treated as dow, not year
 			// "30 15 10 1 1 5" is [sec=30 min=15 hour=10 dom=1 month=1 dow=5] year=any
+			// With AND logic: Jan 1 must be a Friday. Jan 1, 2027 is the next Friday-Jan-1.
 			name:       "6 fields with dow - prefers seconds",
 			spec:       "30 15 10 1 1 5",
 			wantErr:    false,
 			from:       time.Date(2024, 12, 1, 0, 0, 0, 0, loc),
-			wantYear:   2025,
+			wantYear:   2027,
 			wantSecond: 30,
 		},
 		{


### PR DESCRIPTION
## Summary

- Changes DOM/DOW matching to use AND logic by default (consistent with other fields)
- Adds `DowOrDom` ParseOption for legacy OR behavior (robfig/cron compatibility)
- Enables useful scheduling patterns like "last Friday of month"

## Breaking Change

When both day-of-month and day-of-week are specified, **both must now match** (AND logic):

| Expression | Before (OR) | After (AND) |
|------------|-------------|-------------|
| `0 0 15 * FRI` | 15th OR any Friday | 15th that is Friday |
| `0 0 25-31 * FRI` | Days 25-31 OR any Friday | Last Friday of month |

## New Patterns Enabled

```go
"0 0 25-31 * FRI"  // Last Friday of month
"0 0 1-7 * MON"    // First Monday of month
"0 0 13 * FRI"     // Friday the 13th
```

## Migration Path

For legacy OR behavior:
```go
parser := cron.NewParser(
    cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.DowOrDom,
)
```

## Test plan

- [x] All existing tests updated and passing
- [x] New tests for AND mode (default)
- [x] New tests for legacy OR mode (DowOrDom option)
- [x] Next() and Prev() work correctly in both modes
- [x] Documentation updated (README, doc.go, MIGRATION.md)
- [x] Linting passes

Closes #277