### PR TITLE
docs(changelog): add v0.8.0 and v0.9.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,49 @@ features, bug fixes, and modernization improvements.
 ### Planned for v2
 - Context-aware Job interface with graceful shutdown support
 
+## [0.9.0] - 2026-01-16
+
+### Added
+- **Wraparound ranges** ([#276], [PR#278]): Cyclic fields now support ranges where start > end
+  - Hours: `22-2` spans midnight (22, 23, 0, 1, 2)
+  - Day-of-week: `FRI-MON` spans weekend (FRI, SAT, SUN, MON)
+  - Month: `NOV-FEB` spans year boundary (NOV, DEC, JAN, FEB)
+  - Supports step values: `22-2/2` = every 2 hours from 10pm to 2am
+- **`DowOrDom` parser option** ([#277], [PR#279]): Legacy OR mode for DOM/DOW matching
+  - Provides robfig/cron compatibility for users depending on OR behavior
+
+### Changed
+- **BREAKING: DOM/DOW matching now uses AND logic** ([#277], [PR#279]): When both day-of-month
+  and day-of-week are specified, both must match. This is consistent with all other cron fields
+  and enables useful patterns:
+  - `0 0 25-31 * FRI` = last Friday of month
+  - `0 0 1-7 * MON` = first Monday of month
+  - `0 0 13 * FRI` = Friday the 13th
+  - Use `DowOrDom` parser option for legacy OR behavior
+
+### Fixed
+- **Test reliability** ([PR#278]): Fixed flaky chain tests using channel synchronization
+
+[#276]: https://github.com/netresearch/go-cron/issues/276
+[#277]: https://github.com/netresearch/go-cron/issues/277
+[PR#278]: https://github.com/netresearch/go-cron/pull/278
+[PR#279]: https://github.com/netresearch/go-cron/pull/279
+
+## [0.8.0] - 2025-12-26
+
+### Added
+- **`FullParser()` convenience function** ([PR#266]): Pre-configured parser with all features enabled
+  (seconds, year, hash, extended syntax)
+- **`YearOptional` parser option** ([PR#266]): Auto-detect year field by value >= 100
+
+### Changed
+- **Security hardening**: Improved workflow permissions and branch protection documentation
+
+### Documentation
+- Updated changelog with v0.7.1 contributor attribution
+
+[PR#266]: https://github.com/netresearch/go-cron/pull/266
+
 ## [0.7.1] - 2025-12-17
 
 ### Fixed


### PR DESCRIPTION
## Summary

Add missing changelog entries for:
- v0.8.0 (released 2025-12-26)
- v0.9.0 (preparing to release)

## Changes

### v0.9.0
- **BREAKING**: DOM/DOW matching now uses AND logic by default
- Wraparound ranges support for cyclic fields
- `DowOrDom` parser option for legacy OR behavior

### v0.8.0
- `FullParser()` convenience function
- `YearOptional` parser option

## Test plan

- [x] No code changes, documentation only