### PR TITLE
docs: improve breaking change visibility for v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,14 +15,9 @@ features, bug fixes, and modernization improvements.
 
 ## [0.9.0] - 2026-01-16
 
-### Added
-- **Wraparound ranges** ([#276], [PR#278]): Cyclic fields now support ranges where start > end
-  - Hours: `22-2` spans midnight (22, 23, 0, 1, 2)
-  - Day-of-week: `FRI-MON` spans weekend (FRI, SAT, SUN, MON)
-  - Month: `NOV-FEB` spans year boundary (NOV, DEC, JAN, FEB)
-  - Supports step values: `22-2/2` = every 2 hours from 10pm to 2am
-- **`DowOrDom` parser option** ([#277], [PR#279]): Legacy OR mode for DOM/DOW matching
-  - Provides robfig/cron compatibility for users depending on OR behavior
+> [!WARNING]
+> **Breaking change:** DOM/DOW matching now uses AND logic by default.
+> See [MIGRATION.md](docs/MIGRATION.md#domdow-and-logic-277) for details and the `DowOrDom` legacy option.
 
 ### Changed
 - **BREAKING: DOM/DOW matching now uses AND logic** ([#277], [PR#279]): When both day-of-month
@@ -32,6 +27,15 @@ features, bug fixes, and modernization improvements.
   - `0 0 1-7 * MON` = first Monday of month
   - `0 0 13 * FRI` = Friday the 13th
   - Use `DowOrDom` parser option for legacy OR behavior
+
+### Added
+- **Wraparound ranges** ([#276], [PR#278]): Cyclic fields now support ranges where start > end
+  - Hours: `22-2` spans midnight (22, 23, 0, 1, 2)
+  - Day-of-week: `FRI-MON` spans weekend (FRI, SAT, SUN, MON)
+  - Month: `NOV-FEB` spans year boundary (NOV, DEC, JAN, FEB)
+  - Supports step values: `22-2/2` = every 2 hours from 10pm to 2am
+- **`DowOrDom` parser option** ([#277], [PR#279]): Legacy OR mode for DOM/DOW matching
+  - Provides robfig/cron compatibility for users depending on OR behavior
 
 ### Fixed
 - **Test reliability** ([PR#278]): Fixed flaky chain tests using channel synchronization

--- a/README.md
+++ b/README.md
@@ -52,10 +52,14 @@ import "github.com/robfig/cron/v3"
 import cron "github.com/netresearch/go-cron"
 ```
 
-The API is 100% compatible with robfig/cron v3.
+The API is 100% compatible with robfig/cron v3. However, this fork includes
+knowingly accepted behavior changes that fix bugs and inconsistencies in the
+unmaintained upstream — see the [comparison table above](#why) for a summary.
 
-> [!TIP]
-> See [docs/MIGRATION.md](docs/MIGRATION.md) for a comprehensive migration guide including behavioral differences, type changes, and troubleshooting.
+> [!WARNING]
+> **Behavior differences exist.** While the API is compatible, some runtime behavior
+> has changed (DOM/DOW matching, DST handling, chain execution). Review
+> [docs/MIGRATION.md](docs/MIGRATION.md) before upgrading production systems.
 
 ## Quick Start
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -2,6 +2,12 @@
 
 This guide helps you migrate from [robfig/cron](https://github.com/robfig/cron) v3 to [netresearch/go-cron](https://github.com/netresearch/go-cron).
 
+> [!WARNING]
+> **This fork includes knowingly accepted behavior changes.** While the API is 100%
+> compatible, runtime behavior differs in several areas to fix bugs and inconsistencies
+> in the unmaintained upstream. Review the [Behavioral Differences](#behavioral-differences)
+> section before upgrading production systems.
+
 ## Quick Start
 
 For most users, migration requires only two changes:
@@ -33,7 +39,7 @@ The API is 100% compatible with robfig/cron v3 — no code changes required for 
 
 ## Behavioral Differences
 
-While the API is compatible, there are intentional behavioral changes that fix bugs or improve reliability. These changes may affect your application if you were (knowingly or unknowingly) depending on the original behavior.
+While the API is compatible, there are knowingly accepted behavior changes that fix bugs or improve reliability. These changes may affect your application if you were (knowingly or unknowingly) depending on the original behavior.
 
 ### Bug Fixes That Change Behavior
 


### PR DESCRIPTION
## Summary

Improves visibility of the DOM/DOW breaking change in v0.9.0 based on feedback from #277.

### Changes

- **README.md**: Clarify "100% API compatible" with reference to behavior differences, change `[!TIP]` to `[!WARNING]` for migration guide
- **CHANGELOG.md**: Add `[!WARNING]` callout for v0.9.0, reorder Changed (breaking) before Added sections
- **docs/MIGRATION.md**: Add `[!WARNING]` callout at top with "knowingly accepted behavior changes" language
- **Release notes**: Updated via `gh release edit` with breaking change warning, migration code example, and reorganized sections

### Context

Addresses feedback from @norman-abramovitz in #277 about making the breaking change more prominent. While 0.9.0 allows breaking changes under SemVer, users upgrading from robfig/cron should have clear visibility into behavior differences.

Closes #277

## Test plan

- [ ] Verify README renders correctly with WARNING callout
- [ ] Verify CHANGELOG renders correctly with WARNING callout
- [ ] Verify MIGRATION.md renders correctly with WARNING callout
- [ ] Verify release notes at https://github.com/netresearch/go-cron/releases/tag/v0.9.0