### PR TITLE
fix(docs): correct version reference in RetryWithBackoff migration

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -203,9 +203,9 @@ _, err := c.AddFunc(veryLongString, myFunc)
 // err: "spec exceeds maximum length of 1024 characters"
 ```
 
-#### RetryWithBackoff Semantics (v1.0)
+#### RetryWithBackoff Semantics (v0.6.0)
 
-**Before (v0.x):**
+**Before (robfig/cron):**
 ```go
 // maxRetries=0 meant unlimited retries (DoS risk)
 c := cron.New(cron.WithChain(
@@ -214,7 +214,7 @@ c := cron.New(cron.WithChain(
 // A failing job would retry forever
 ```
 
-**After (v1.0+):**
+**After (netresearch/go-cron v0.6.0+):**
 ```go
 // maxRetries=0 now means no retries (safe default)
 c := cron.New(cron.WithChain(


### PR DESCRIPTION
## Summary

Fixes incorrect version reference in the migration guide.

The RetryWithBackoff semantics change was made in v0.6.0, not a hypothetical v1.0. The migration guide incorrectly referenced "v1.0" and "After (v1.0+)" when it should reference the actual version where this change was introduced.

### Changes

- `#### RetryWithBackoff Semantics (v1.0)` → `#### RetryWithBackoff Semantics (v0.6.0)`
- `**Before (v0.x):**` → `**Before (robfig/cron):**`
- `**After (v1.0+):**` → `**After (netresearch/go-cron v0.6.0+):**`

## Test plan

- [x] Verify version references match CHANGELOG.md (v0.6.0 breaking change)