### PR TITLE
feat(validate): add DOM/DOW AND logic warnings

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -532,6 +532,16 @@ func (c *Cron) ScheduleJob(schedule Schedule, cmd Job, opts ...JobOption) (Entry
 		opt(entry)
 	}
 
+	// Log info if both DOM and DOW are restricted (AND logic in effect)
+	if spec, ok := schedule.(*SpecSchedule); ok {
+		if spec.Dom&starBit == 0 && spec.Dow&starBit == 0 && !spec.DowOrDom {
+			c.logger.Info("schedule uses AND logic for day matching",
+				"reason", "both day-of-month and day-of-week are restricted",
+				"hint", "use DowOrDom parser option for legacy OR behavior",
+				"entry", entry.Name)
+		}
+	}
+
 	// Check for duplicate name
 	if entry.Name != "" {
 		if _, exists := c.nameIndex[entry.Name]; exists {


### PR DESCRIPTION
## Summary

- Add `Warnings` field to `SpecAnalysis` struct for programmatic inspection
- Add Cron-level logger warning when scheduling jobs with both DOM and DOW restricted
- Add comprehensive tests for both warning mechanisms

When both day-of-month and day-of-week are restricted (not wildcards), AND logic is used (both must match). This can surprise users migrating from robfig/cron which used OR logic.

## What this adds

### 1. SpecAnalysis.Warnings (Programmatic)
```go
result := cron.AnalyzeSpec("0 9 15 * FRI")
if len(result.Warnings) > 0 {
    for _, w := range result.Warnings {
        log.Printf("Warning: %s", w)
    }
}
// Output: "Warning: both day-of-month and day-of-week are restricted - 
//          using AND logic (both must match); use DowOrDom parser option 
//          for legacy OR behavior"
```

### 2. Cron Logger (Automatic)
```go
c := cron.New(cron.WithLogger(cron.VerbosePrintfLogger(log.Default())))
c.AddFunc("0 9 15 * FRI", myJob)
// Logs: "schedule uses AND logic for day matching, reason=both day-of-month 
//        and day-of-week are restricted, hint=use DowOrDom parser option 
//        for legacy OR behavior, entry=<name>"
```

## Suppression

Warnings are suppressed when:
- Either DOM or DOW is a wildcard (`*`) or `?`
- The `DowOrDom` parser option is used (legacy OR behavior)

## Test plan

- [x] All existing tests pass
- [x] New tests for `SpecAnalysis.Warnings` covering all cases
- [x] New tests for Cron logger warning via AddFunc and ScheduleJob
- [x] Tests verify warnings are NOT produced when DowOrDom option is used
- [x] Lint, vulncheck, and full test suite pass

Addresses visibility concerns raised in #277.

---

🤖 Generated with [Claude Code](https://claude.ai/code)