### PR TITLE
chore(release): prepare v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ features, bug fixes, and modernization improvements.
 ### Planned for v2
 - Context-aware Job interface with graceful shutdown support
 
+## [0.9.1] - 2026-01-17
+
+### Added
+- **DOM/DOW AND logic warnings** ([#277], [PR#285]): Runtime notification when both day-of-month
+  and day-of-week are restricted, helping users understand AND logic behavior
+  - `SpecAnalysis.Warnings` field for programmatic inspection via `AnalyzeSpec()`
+  - Cron-level logger emits info message when scheduling affected jobs
+  - Warnings suppressed when `DowOrDom` option is used (legacy OR behavior)
+
+### Documentation
+- **ADR-008** ([PR#284]): Architecture decision record documenting DOM/DOW AND logic rationale
+- Improved breaking change visibility in README, CHANGELOG, and MIGRATION.md ([PR#282])
+- Fixed version reference in RetryWithBackoff migration guide ([PR#283])
+
+[PR#282]: https://github.com/netresearch/go-cron/pull/282
+[PR#283]: https://github.com/netresearch/go-cron/pull/283
+[PR#284]: https://github.com/netresearch/go-cron/pull/284
+[PR#285]: https://github.com/netresearch/go-cron/pull/285
+
 ## [0.9.0] - 2026-01-16
 
 > [!WARNING]


### PR DESCRIPTION
## Summary

Prepare v0.9.1 release with CHANGELOG update.

## Changes since v0.9.0

### Added
- **DOM/DOW AND logic warnings** (#285): Runtime notification when both day-of-month and day-of-week are restricted
  - `SpecAnalysis.Warnings` field for programmatic inspection
  - Cron-level logger emits info message when scheduling affected jobs

### Documentation
- ADR-008 documenting DOM/DOW AND logic decision (#284)
- Improved breaking change visibility (#282)
- Fixed version reference in migration guide (#283)

## After merge

Will create signed tag `v0.9.1` and GitHub release.