### PR TITLE
docs: address review comments from PR #291

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -313,7 +313,9 @@ func healthHandler(c *cron.Cron) http.HandlerFunc {
         entries := c.Entries()
         status := map[string]any{
             "scheduled_jobs": len(entries),
-            "next_run":       entries[0].Next, // Entries sorted by next run
+        }
+        if len(entries) > 0 {
+            status["next_run"] = entries[0].Next // Entries sorted by next run
         }
         json.NewEncoder(w).Encode(status)
     }

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -91,7 +91,7 @@ c := cron.New(cron.WithParser(cron.NewParser(
 
 **Check: Is your job panicking silently?**
 
-Without `Recover()` wrapper, panics are logged but may be missed:
+Without `Recover()` wrapper, panics are caught by the scheduler but not logged (only passed to `OnJobComplete` hook):
 
 ```go
 c := cron.New(cron.WithChain(
@@ -289,7 +289,7 @@ c := cron.New(cron.WithChain(
 ))
 ```
 
-Without `Recover()`, job panics terminate the goroutine but are logged.
+Without `Recover()`, the scheduler catches panics internally (it never crashes), but they are only visible via the `OnJobComplete` hook's `recovered` parameter. Use `Recover()` to log panics explicitly.
 
 ---
 

--- a/docs/adr/ADR-009-entry-id-sentinel.md
+++ b/docs/adr/ADR-009-entry-id-sentinel.md
@@ -35,7 +35,7 @@ func (e Entry) Valid() bool { return e.ID != 0 }
 // ID allocation skips 0 on wraparound
 c.nextID++
 if c.nextID == 0 {
-    c.nextID = 1 // Skip 0; Entry.Valid() uses 0 as invalid sentinel
+    c.nextID = 1 // Skip 0 to maintain EntryID(0) as the invalid sentinel used by Entry.Valid()
 }
 ```
 

--- a/docs/adr/ADR-010-channel-synchronization.md
+++ b/docs/adr/ADR-010-channel-synchronization.md
@@ -141,8 +141,8 @@ func (c *Cron) Remove(id EntryID) Entry {
 Some operations must only be called from the run loop:
 
 ```go
-// removeEntry must only be called from the run loop or when holding runningMu
-// and c.running == false. Calling from elsewhere causes data races.
+// removeEntry must only be called from the run loop, or when holding runningMu
+// with c.running == false. Calling from elsewhere causes data races.
 func (c *Cron) removeEntry(id EntryID) Entry {
     // ...
 }


### PR DESCRIPTION
## Summary

Addresses Copilot review comments from PR #291.

## Fixes

| File | Issue | Fix |
|------|-------|-----|
| OPERATIONS.md | `entries[0]` without length check | Added `if len(entries) > 0` guard |
| TROUBLESHOOTING.md | Misleading panic behavior claim | Clarified that scheduler has internal `recover()` and never crashes |
| ADR-009 | Comment clarity | Improved wording for sentinel explanation |
| ADR-010 | Ambiguous "and"/"or" condition | Clarified with comma placement |

## Not Changed

| File | Reason |
|------|--------|
| ADR README date format | Table uses consistent YYYY-MM format throughout; ADR files use YYYY-MM-DD internally which is fine |

## Test plan

- [x] All documentation fixes are accurate
- [x] Panic behavior verified against cron.go:801-804 (internal recover exists)