### PR TITLE
fix(ci): skip auto-approve for fork PRs

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -43,7 +43,11 @@ jobs:
     name: Auto-Approve (Solo Maintainer)
     runs-on: ubuntu-latest
     needs: quality-gate
-    if: github.event.pull_request.draft == false
+    # Only auto-approve non-draft PRs from the same repo (not forks)
+    # Fork PRs require manual review by maintainer
+    if: |
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Harden Runner


### PR DESCRIPTION
## Summary
- Skip auto-approve job for PRs from forks where GitHub security restrictions prevent GITHUB_TOKEN from approving
- Auto-approval is only meaningful for same-repo PRs (solo maintainer workflow)
- External contributions from forks should be manually reviewed anyway

## Test plan
- [x] Verified workflow YAML syntax is correct
- [x] CI will validate this change on its own PR
- [x] Once merged, fork PRs will show the auto-approve job as skipped instead of failing

Fixes workflow failure on PR #304.