### PR TITLE
feat(cron): support updating schedules at runtime

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -219,6 +219,16 @@ linters:
         path: spec\.go
         text: "(Next|Prev)"
 
+      # Central run loop has intentional complexity and length; splitting would obscure ownership
+      # Exclude complexity/length linters for cron.go to avoid brittle text matching
+      - linters:
+          - gocognit
+          - gocyclo
+          - cyclop
+          - funlen
+        path: cron\.go
+        text: "run"
+
       # parse() and getRangeWithHash handle multiple ParseOption flags and hash expression scenarios
       # Complexity is inherent to flexible cron expression parsing with hash support
       - linters:


### PR DESCRIPTION
## Summary

Add runtime APIs to update existing cron entry schedules without removing/re-adding the entry. Integrates a safe, run-loop-mediated update path that recomputes next run and reorders the scheduling heap in O(log n).

- `UpdateSchedule(id EntryID, schedule Schedule) error`
- `UpdateJob(id EntryID, spec string) error`
- `UpdateScheduleByName(name string, schedule Schedule) error`
- `UpdateJobByName(name, spec string) error`
- New `ErrEntryNotFound` error variable

**Concurrency semantics:**
- Running: updates serialized via run loop, no additional locking needed
- Stopped: guarded by `runningMu`, updates happen in place

**Use case:** This directly addresses the dynamic rescheduling pattern seen in [weaviate/weaviate](https://github.com/weaviate/weaviate) (15.5k stars), which currently maintains ~150 lines of wrapper code doing `RemoveByName()` + `WaitGroup` + `AddJob()` with subtle race conditions. The atomic `UpdateJobByName` eliminates all of that.

Closes #166

Based on work by James Rouzier (@jrouzierinverse) in #304, squashed into a single signed commit.

## Test plan
- [x] All existing tests pass
- [x] New tests for UpdateSchedule, UpdateJob, UpdateScheduleByName, UpdateJobByName
- [x] Error path tests (bad spec, entry not found)
- [x] Tests for both stopped and running states
- [x] FakeClock-based timing verification