### PR TITLE
test: improve coverage from 94.0% to 96.6%

### DIFF
--- a/heap_test.go
+++ b/heap_test.go
@@ -486,6 +486,18 @@ func TestRemoveAtBoundaryIdxEqualsLen(t *testing.T) {
 	}
 }
 
+// TestHeapPopEmpty tests Pop() on an empty heap returns nil (defensive check).
+func TestHeapPopEmpty(t *testing.T) {
+	h := &entryHeap{}
+	heap.Init(h)
+
+	// Direct Pop() on empty heap should return nil (defensive path)
+	result := h.Pop()
+	if result != nil {
+		t.Errorf("Pop() on empty heap should return nil, got %v", result)
+	}
+}
+
 // TestRemoveAtIdxLastValid tests that idx = len(*h) - 1 (last valid index) works.
 // This is the "just inside boundary" case.
 func TestRemoveAtIdxLastValid(t *testing.T) {

--- a/introspect_test.go
+++ b/introspect_test.go
@@ -497,6 +497,23 @@ func TestIntrospectionNilSchedule(t *testing.T) {
 	}
 }
 
+// scheduleWithoutPrev implements Schedule but NOT ScheduleWithPrev.
+type scheduleWithoutPrev struct{}
+
+func (s scheduleWithoutPrev) Next(t time.Time) time.Time {
+	return t.Add(time.Hour)
+}
+
+// TestMatches_ScheduleWithoutPrev tests Matches() with a schedule that doesn't implement ScheduleWithPrev.
+func TestMatches_ScheduleWithoutPrev(t *testing.T) {
+	sched := scheduleWithoutPrev{}
+
+	// Matches should return false for schedules that don't implement ScheduleWithPrev
+	if Matches(sched, time.Now()) {
+		t.Error("Matches() should return false for schedules without ScheduleWithPrev")
+	}
+}
+
 // TestIntrospectionConcurrent tests thread safety of introspection functions.
 func TestIntrospectionConcurrent(t *testing.T) {
 	schedule, err := ParseStandard("0 * * * *")


### PR DESCRIPTION
## Summary

- Add targeted tests for ~20 previously uncovered code paths across 7 test files
- Coverage improves from **94.0% → 96.6%** (+2.6 percentage points, 489 new test lines)
- Key coverage gains: `parseFields` 25.9%→100%, `handleTimeBackwards` 57.1%→100%, `toError` 66.7%→100%, `PanicError.String/Unwrap` 0%→covered, `normalizeDSTDayPrev` 66.7%→100%

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Coverage verified at 96.6% via `go tool cover -func`
- [x] Pre-commit hooks pass (fmt, tidy, build, lint, gitleaks)
- [x] Pre-push hooks pass (test, lint-full, vulncheck)