### PR TITLE
docs: update README and API reference for v0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Available wrappers:
 | `RetryOnError` | Retry on error return (`ErrorJob` interface) |
 | `CircuitBreaker` | Stop execution after consecutive failures |
 
-All wrappers implement `JobWithContext` and propagate the incoming context to inner jobs.
+Concurrency and resilience wrappers (`Recover`, `SkipIfStillRunning`, `DelayIfStillRunning`, `Timeout`, `TimeoutWithContext`, `Jitter`, `JitterWithLogger`) implement `JobWithContext` and propagate the incoming context to inner jobs. Retry and circuit breaker wrappers (`RetryWithBackoff`, `RetryOnError`, `CircuitBreaker`) do not currently forward context.
 
 ## Validation
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -889,9 +889,11 @@ fakeClock.Advance(time.Hour) // Trigger jobs deterministically
 func WithContext(ctx context.Context) Option
 ```
 
-WithContext sets the base context for all job executions. When `Stop()` is called,
-this context is canceled, signaling all running `JobWithContext` jobs to shut down.
-If not specified, `context.Background()` is used.
+WithContext sets the parent context from which the cron scheduler derives its
+own cancelable child context (via `context.WithCancel`) for all job executions.
+`Stop()` cancels only that derived child context, signaling all running
+`JobWithContext` jobs to shut down; the caller-provided context is not canceled
+by `Stop()`. If not specified, `context.Background()` is used as the parent.
 
 **Example:**
 ```go
@@ -1875,8 +1877,8 @@ MaxSpecLength is the maximum allowed length for a cron spec string.
 var ErrEntryNotFound = errors.New("cron: entry not found")
 ```
 
-Returned by update methods (`UpdateSchedule`, `UpdateEntry`, `UpsertJob`, etc.)
-when the specified entry does not exist.
+Returned by update methods (`UpdateSchedule`, `UpdateEntry`, `UpdateEntryByName`,
+`UpdateEntryJob`, `UpdateEntryJobByName`) when the specified entry does not exist.
 
 ### ErrNilJob
 
@@ -1918,7 +1920,8 @@ Returned when adding an entry with a name that already exists.
 var ErrEmptySpec = &ValidationError{Message: "empty spec string"}
 ```
 
-Returned by `AnalyzeSpec` when an empty spec string is provided.
+Set as the `Error` field on the `SpecAnalysis` result returned by `AnalyzeSpec`
+and `AnalyzeSpecWithHash` when an empty spec string is provided.
 
 ---
 


### PR DESCRIPTION
## Summary

- **README.md**: Added 7 new sections covering all features added since the original fork — named jobs, runtime updates, context support, full wrappers table, validation, observability, FakeClock testing, graceful shutdown, slog support. Expanded the "Why?" comparison table.
- **API_REFERENCE.md**: Added ~30 missing entries — types (`JobWithContext`, `FuncJobWithContext`, `ErrorJob`, `FuncErrorJob`, `NamedJob`, `ObservabilityHooks`, `SpecAnalysis`, `ValidationError`, `PanicError`), Cron methods (`EntryByName`, `EntriesByTag`, `RemoveByName`, `RemoveByTag`, `IsRunning`, `ValidateSpec`, `StopAndWait`, `StopWithTimeout`, `ScheduleJob`, `AddOnceFunc`, `AddOnceJob`, `ScheduleOnceJob`), options (`WithContext`, `WithMaxEntries`, `WithObservability`, `WithSecondOptional`, `WithMinEveryInterval`, `WithMaxSearchYears`, `WithRunImmediately`, `WithRunOnce`), wrappers (`RetryWithBackoff`, `RetryOnError`, `CircuitBreaker`, `TimeoutWithContext`), functions (`ValidateSpec`, `ValidateSpecWith`, `ValidateSpecs`, `AnalyzeSpec`, `AnalyzeSpecWithHash`, `Every`), errors (`ErrMaxEntriesReached`, `ErrDuplicateName`, `ErrEmptySpec`).

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] All pre-commit and pre-push hooks pass
- [ ] Review rendered markdown for formatting