### PR TITLE
test: cover PrevN early-stop on zero time branch

### DIFF
--- a/introspect_test.go
+++ b/introspect_test.go
@@ -501,6 +501,18 @@ func TestPrevNWithDailySchedule(t *testing.T) {
 	}
 }
 
+// TestPrevN_EarlyStopOnZeroTime tests that PrevN stops when Prev() returns zero time.
+func TestPrevN_EarlyStopOnZeroTime(t *testing.T) {
+	// TriggeredSchedule.Prev() always returns zero time
+	sched := TriggeredSchedule{}
+	times := PrevN(sched, time.Now(), 5)
+	if times == nil {
+		t.Fatal("PrevN(TriggeredSchedule, 5) returned nil, want empty slice")
+	} else if len(times) != 0 {
+		t.Errorf("PrevN(TriggeredSchedule, 5) returned %d times, want 0", len(times))
+	}
+}
+
 // TestPrevN_ScheduleWithoutPrev tests PrevN with a schedule that doesn't implement ScheduleWithPrev.
 func TestPrevN_ScheduleWithoutPrev(t *testing.T) {
 	sched := scheduleWithoutPrev{}


### PR DESCRIPTION
## Summary

- Add `TestPrevN_EarlyStopOnZeroTime` using `TriggeredSchedule` (whose `Prev()` always returns zero) to exercise the `break` path in `PrevN`
- Brings `PrevN` coverage from 92.9% to 100%

Follow-up to [PR #328](https://github.com/netresearch/go-cron/pull/328) which merged with `codecov/patch` failing at 86.66%.

## Test plan

- [x] `TestPrevN_EarlyStopOnZeroTime` passes
- [x] `PrevN` at 100% coverage (`go tool cover -func`)
- [x] Full suite passes with all pre-push hooks