### PR TITLE
test: add mutation-killing tests to improve gremlins efficacy

### DIFF
--- a/introspect_test.go
+++ b/introspect_test.go
@@ -701,6 +701,34 @@ func TestMatches_ScheduleWithoutPrev(t *testing.T) {
 	}
 }
 
+// TestNextN_ZeroReturnsNil kills CONDITIONALS_BOUNDARY at introspect.go:21:26
+// where `n <= 0` could become `n < 0`, making n=0 return empty slice instead of nil.
+func TestNextN_ZeroReturnsNil(t *testing.T) {
+	schedule, err := ParseStandard("0 * * * *")
+	if err != nil {
+		t.Fatalf("ParseStandard failed: %v", err)
+	}
+
+	times := NextN(schedule, time.Now(), 0)
+	if times != nil {
+		t.Errorf("NextN(schedule, t, 0) = %v (len=%d), want nil", times, len(times))
+	}
+}
+
+// TestPrevN_ZeroReturnsNil kills CONDITIONALS_BOUNDARY at introspect.go:169
+// where `n <= 0` could become `n < 0`.
+func TestPrevN_ZeroReturnsNil(t *testing.T) {
+	schedule, err := ParseStandard("0 * * * *")
+	if err != nil {
+		t.Fatalf("ParseStandard failed: %v", err)
+	}
+
+	times := PrevN(schedule, time.Now(), 0)
+	if times != nil {
+		t.Errorf("PrevN(schedule, t, 0) = %v (len=%d), want nil", times, len(times))
+	}
+}
+
 // TestIntrospectionConcurrent tests thread safety of introspection functions.
 func TestIntrospectionConcurrent(t *testing.T) {
 	schedule, err := ParseStandard("0 * * * *")

--- a/parser_test.go
+++ b/parser_test.go
@@ -2301,3 +2301,26 @@ func TestFullParserReturnsConsistentInstance(t *testing.T) {
 		t.Errorf("FullParser instances produce different results: %v vs %v", n1, n2)
 	}
 }
+
+func TestParseSpecLengthLimit_ExactBoundary(t *testing.T) {
+	// Kills CONDITIONALS_BOUNDARY mutation at parser.go:404 where (>) → (>=)
+	// A spec of exactly MaxSpecLength chars should NOT trigger the length error.
+	spec := strings.Repeat("*", MaxSpecLength)
+	_, err := standardParser.Parse(spec)
+	// May fail validation for other reasons, but NOT "spec too long"
+	if err != nil && strings.Contains(err.Error(), "spec too long") {
+		t.Errorf("spec of exactly MaxSpecLength (%d) chars should not trigger length error", MaxSpecLength)
+	}
+}
+
+func TestMustParseInt_Zero(t *testing.T) {
+	// Kills CONDITIONALS_BOUNDARY mutation at parser.go:1396 where (<) → (<=)
+	// mustParseInt("0") should return 0 without error.
+	val, err := mustParseInt("0")
+	if err != nil {
+		t.Errorf("mustParseInt(\"0\") returned error: %v", err)
+	}
+	if val != 0 {
+		t.Errorf("mustParseInt(\"0\") = %d, want 0", val)
+	}
+}


### PR DESCRIPTION
## Summary

- Add 22 targeted tests across 7 test files to kill surviving mutants identified by gremlins mutation testing (baseline: 84.07% efficacy, 126 LIVED mutants)
- Tests target boundary conditions, arithmetic sign flips, and condition negations — no source code changes
- Includes a reusable `capturingLogger` test helper for verifying log output at mutation boundaries

## Targeted Mutations

| File | Tests | Mutations Killed |
|------|-------|-----------------|
| `constantdelay_test.go` | 1 (2 subtests) | Next/Prev nanosecond rounding `−` → `+` |
| `introspect_test.go` | 2 | `n <= 0` → `n < 0` boundary |
| `retry_test.go` | 7 + helper | backoff formula, first-attempt delay (×3), isOpen threshold, cooldown remaining, log threshold |
| `missed_test.go` | 2 | grace period `>` → `>=`, maxMissedRuns `>=` → `>` |
| `parser_test.go` | 2 | MaxSpecLength `>` → `>=`, mustParseInt `< 0` → `<= 0` |
| `spec_test.go` | 4 | weekdayOccurrence, nearestWeekday, lastWeekdayOfMonth, retreatMinute |
| `workflow_test.go` | 3 | shouldTriggerChild no-deps, removeEntry multi-child cleanup, removeDependencyDirect multi-parent |

## Test plan

- [x] All 22 new tests pass individually (`go test -run <pattern>`)
- [x] Full test suite passes (`go test -count=1 -timeout 180s ./...`)
- [x] Pre-push hooks pass (lint, vulncheck, tests)
- [ ] CI passes
- [ ] Re-run gremlins to verify efficacy improvement (target: >85%)