### PR TITLE
feat: allow quoted TZ and CRON_TZ values in spec strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,10 @@ c.AddFunc("CRON_TZ=America/New_York 0 6 * * *", myFunc)
 
 // Legacy TZ= prefix also supported
 c.AddFunc("TZ=Europe/Berlin 0 9 * * *", myFunc)
+
+// Quoted values are accepted (common shell habit)
+c.AddFunc(`TZ="America/Chicago" 0 8 * * *`, myFunc)
+c.AddFunc(`CRON_TZ='Asia/Tokyo' 30 4 * * *`, myFunc)
 ```
 
 Or set default timezone for all jobs:

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -851,6 +851,7 @@ c.AddFunc("CRON_TZ=America/New_York 0 4 * * *", job) // 4 AM is safe
 - Set default location to UTC for predictability
 - Use `CRON_TZ=` prefix for per-job timezone
 - Use IANA timezone names (not abbreviations like "EST")
+- Quoted values are accepted: `CRON_TZ="America/New_York"` and `CRON_TZ='UTC'` both work
 - Avoid scheduling during DST transition hours (2-3 AM)
 - Log times in multiple zones for debugging
 

--- a/docs/DST_HANDLING.md
+++ b/docs/DST_HANDLING.md
@@ -107,6 +107,10 @@ c := cron.New(cron.WithLocation(nyc))
 // Option 2: Per-schedule timezone prefix
 c.AddFunc("TZ=America/New_York 0 9 * * *", job)
 c.AddFunc("CRON_TZ=Europe/London 0 9 * * *", job)
+
+// Quoted values also accepted (common shell convention)
+c.AddFunc(`TZ="America/New_York" 0 9 * * *`, job)
+c.AddFunc(`CRON_TZ='Europe/London' 0 9 * * *`, job)
 ```
 
 ### Location Priority

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -201,6 +201,9 @@ if _, err := time.LoadLocation("America/New_York"); err != nil {
 }
 ```
 
+> **Note:** Quoted timezone values are accepted — `TZ="America/New_York"` and `TZ='UTC'` both work. Matching single or double quotes are stripped before validation. Mismatched quotes (e.g., `TZ="UTC'`) are rejected.
+```
+
 ---
 
 ### Symptom: Timezone not recognized in container

--- a/docs/adr/ADR-021-quoted-timezone-values.md
+++ b/docs/adr/ADR-021-quoted-timezone-values.md
@@ -1,0 +1,112 @@
+# ADR-021: Quoted Timezone Values in Spec Strings
+
+## Status
+Accepted
+
+## Date
+2026-02-23
+
+## Context
+
+Unix/Linux shell users habitually quote environment variable values. When writing cron specs with timezone prefixes, they naturally write:
+
+```
+TZ="America/New_York" 0 9 * * *
+TZ='UTC' * * * * *
+CRON_TZ="Asia/Tokyo" 30 4 * * *
+```
+
+Prior to this change, these specs failed with `invalid character '"' at position 0 in timezone` because the `validateTimezone()` function (correctly) rejects quote characters as invalid IANA timezone name characters.
+
+This was reported as [#335](https://github.com/netresearch/go-cron/issues/335).
+
+## Decision
+
+Strip matching quote pairs from the timezone value **before** validation and loading. The stripping happens in `parseTimezone()` after extracting the raw value between `=` and the first space, but before calling `validateTimezone()`.
+
+### What IS Supported
+
+| Input | Parsed timezone | Notes |
+|-------|----------------|-------|
+| `TZ="UTC" * * * * *` | `UTC` | Double quotes stripped |
+| `TZ='UTC' * * * * *` | `UTC` | Single quotes stripped |
+| `CRON_TZ="America/New_York" 0 9 * * *` | `America/New_York` | Works with both prefixes |
+| `TZ=UTC * * * * *` | `UTC` | Unquoted still works (backwards-compatible) |
+
+### What is NOT Supported
+
+| Input | Result | Rationale |
+|-------|--------|-----------|
+| `TZ="America/New York" ...` | Error (parses `"America/New` due to space split) | IANA timezone names never contain spaces. Supporting spaces inside quotes would require quote-aware tokenization, a disproportionate complexity increase for a non-existent use case. |
+| `TZ="UTC' ...` | Error (mismatched quotes not stripped, `"` fails validation) | Only matching pairs are stripped |
+| `TZ="" ...` | Error (empty timezone after stripping) | Empty timezone is always invalid |
+| `TZ="UTC ...` | Error (opening quote without closing, `"` fails validation) | Partial quoting is not supported |
+
+### Implementation
+
+The change is minimal — 5 lines added to `parseTimezone()` in `parser.go`:
+
+```go
+if len(tzName) >= 2 {
+    if (tzName[0] == '"' && tzName[len(tzName)-1] == '"') ||
+        (tzName[0] == '\'' && tzName[len(tzName)-1] == '\'') {
+        tzName = tzName[1 : len(tzName)-1]
+    }
+}
+```
+
+Key design choices:
+- **Strip before validation**: Quotes are removed before `validateTimezone()` runs, so the validation logic and character allowlist remain unchanged
+- **No changes to `isValidTimezoneChar()`**: Quote characters are still invalid in timezone names — we just strip them before they reach validation
+- **Space-based splitting unchanged**: The parser still splits on the first space character, so `TZ="America/New York"` does not work (and shouldn't, since no real IANA timezone contains a space)
+
+## Consequences
+
+### Positive
+
+- **Shell user ergonomics**: Users who copy-paste from shell configs or write specs by muscle memory no longer get confusing errors
+- **Backwards-compatible**: Unquoted values continue to work identically
+- **Zero risk**: Stripping quotes before validation means security properties are preserved — path traversal, injection, and length checks still apply to the actual timezone name
+- **Minimal code change**: 5 lines of production code, no new dependencies
+
+### Negative
+
+- **Slight parsing ambiguity**: A timezone value literally named `"UTC"` (with quotes as part of the name) would now be interpreted as `UTC`. This is not a real concern since IANA timezone names never contain quotes.
+
+### Neutral
+
+- **No behavioral change for valid specs**: This is purely additive — previously-invalid specs now parse, previously-valid specs are unchanged
+
+## Alternatives Considered
+
+### 1. Document That Quoting Is Not Allowed
+
+Add documentation telling users not to quote timezone values.
+
+**Rejected because:**
+- Users make this mistake by reflex from years of shell scripting
+- A one-time 5-line fix is better than perpetual user confusion
+- "Don't do that" documentation is rarely read before the error occurs
+
+### 2. Add Quotes to Valid Character Set
+
+Allow `"` and `'` through `isValidTimezoneChar()` and let `time.LoadLocation()` handle the error.
+
+**Rejected because:**
+- `time.LoadLocation("\"UTC\"")` would fail with a confusing "unknown time zone" error
+- Validation should catch the issue early with a clear message
+- Quotes are genuinely not valid in IANA timezone names
+
+### 3. Quote-Aware Tokenization
+
+Rewrite the spec parser to handle quoted fields, supporting spaces inside quotes.
+
+**Rejected because:**
+- Disproportionate complexity for zero practical benefit (no IANA timezone contains spaces)
+- Would change the fundamental parsing model
+- Higher risk of regressions
+
+## References
+
+- [#335](https://github.com/netresearch/go-cron/issues/335): Feature request for quoted TZ/CRON_TZ values
+- [IANA Time Zone Database](https://www.iana.org/time-zones): Authoritative timezone name list (no names contain quotes or spaces)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,6 +36,7 @@ An Architecture Decision Record captures a significant decision made about the a
 | [ADR-018](ADR-018-run-flags.md) | Run-Immediately and Run-Once Entry Flags | Accepted | 2025-12 |
 | [ADR-019](ADR-019-atomic-entry-limit.md) | Atomic CAS for Entry Count Limiting | Accepted | 2025-12 |
 | [ADR-020](ADR-020-feature-scope-boundary.md) | Feature Scope and Boundary Definition | Accepted | 2026-01 |
+| [ADR-021](ADR-021-quoted-timezone-values.md) | Quoted Timezone Values in Spec Strings | Accepted | 2026-02 |
 
 ## ADR Template
 

--- a/parser.go
+++ b/parser.go
@@ -319,6 +319,8 @@ func (p Parser) WithHashKey(key string) Parser {
 const MaxSpecLength = 1024
 
 // parseTimezone extracts and validates the timezone from a spec string.
+// Matching single or double quotes around the timezone value are stripped
+// (e.g., TZ="America/New_York" is treated as TZ=America/New_York).
 // Returns the location, remaining spec string, and any error.
 func parseTimezone(spec string) (*time.Location, string, error) {
 	if !strings.HasPrefix(spec, "TZ=") && !strings.HasPrefix(spec, "CRON_TZ=") {
@@ -332,6 +334,16 @@ func parseTimezone(spec string) (*time.Location, string, error) {
 
 	eq := strings.Index(spec, "=")
 	tzName := spec[eq+1 : i]
+
+	// Strip matching quotes — shell users habitually write TZ="America/New_York"
+	// or TZ='UTC'. Only matching pairs are stripped; mismatched quotes are left
+	// intact and will fail validation below.
+	if len(tzName) >= 2 {
+		if (tzName[0] == '"' && tzName[len(tzName)-1] == '"') ||
+			(tzName[0] == '\'' && tzName[len(tzName)-1] == '\'') {
+			tzName = tzName[1 : len(tzName)-1]
+		}
+	}
 
 	if err := validateTimezone(tzName); err != nil {
 		return nil, "", fmt.Errorf("invalid timezone %q: %w", tzName, err)

--- a/parser_test.go
+++ b/parser_test.go
@@ -1147,6 +1147,73 @@ func TestTimezoneValidation(t *testing.T) {
 	}
 }
 
+// TestTimezoneQuotedValues tests that quoted TZ/CRON_TZ values are accepted (#335).
+// Shell users habitually write TZ="America/New_York" or TZ='UTC'.
+// We strip matching quotes before validation so these specs parse correctly.
+func TestTimezoneQuotedValues(t *testing.T) {
+	tokyo, _ := time.LoadLocation("Asia/Tokyo")
+	nyc, _ := time.LoadLocation("America/New_York")
+
+	tests := []struct {
+		name    string
+		spec    string
+		wantLoc *time.Location
+		wantErr string
+	}{
+		// Double-quoted — should be accepted
+		{"double-quoted UTC", `TZ="UTC" * * * * *`, time.UTC, ""},
+		{"double-quoted city", `TZ="America/New_York" 0 5 * * *`, nyc, ""},
+		{"double-quoted CRON_TZ", `CRON_TZ="Asia/Tokyo" 30 4 * * *`, tokyo, ""},
+
+		// Single-quoted — should be accepted
+		{"single-quoted UTC", `TZ='UTC' * * * * *`, time.UTC, ""},
+		{"single-quoted city", `TZ='America/New_York' 0 5 * * *`, nyc, ""},
+		{"single-quoted CRON_TZ", `CRON_TZ='Asia/Tokyo' 30 4 * * *`, tokyo, ""},
+
+		// Mismatched quotes — should error
+		{"mismatched double-single", `TZ="UTC' * * * * *`, nil, "invalid"},
+		{"mismatched single-double", `TZ='UTC" * * * * *`, nil, "invalid"},
+
+		// Empty after stripping — should error
+		{"double-quoted empty", `TZ="" * * * * *`, nil, "empty timezone"},
+		{"single-quoted empty", `TZ='' * * * * *`, nil, "empty timezone"},
+
+		// Only opening quote (no closing) — quote becomes part of value
+		{"only opening double quote", `TZ="UTC * * * * *`, nil, "invalid"},
+		{"only opening single quote", `TZ='UTC * * * * *`, nil, "invalid"},
+
+		// Only closing quote — quote becomes part of value
+		{"only closing double quote", `TZ=UTC" * * * * *`, nil, "invalid"},
+		{"only closing single quote", `TZ=UTC' * * * * *`, nil, "invalid"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sched, err := ParseStandard(tt.spec)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("ParseStandard(%q) expected error containing %q, got nil", tt.spec, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("ParseStandard(%q) error = %v, want error containing %q", tt.spec, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseStandard(%q) unexpected error: %v", tt.spec, err)
+			}
+			// Verify the parsed schedule uses the correct timezone
+			cronSched, ok := sched.(*SpecSchedule)
+			if !ok {
+				t.Fatalf("ParseStandard(%q) returned %T, want *SpecSchedule", tt.spec, sched)
+			}
+			if cronSched.Location.String() != tt.wantLoc.String() {
+				t.Errorf("ParseStandard(%q) location = %v, want %v", tt.spec, cronSched.Location, tt.wantLoc)
+			}
+		})
+	}
+}
+
 // TestWithMaxSearchYears tests the WithMaxSearchYears parser option
 func TestParserWithMaxSearchYears(t *testing.T) {
 	// Create a schedule for Feb 30 (impossible date - will never match)


### PR DESCRIPTION
## Summary

Closes #335

Shell users habitually write `TZ="America/New_York"` or `TZ='UTC'` when specifying timezones in cron specs. Previously these were rejected with a confusing `invalid character '"'` error. Now matching single or double quotes are stripped before validation.

## Changes

- **`parser.go`**: Strip matching quote pairs in `parseTimezone()` before validation (5 lines)
- **`parser_test.go`**: 14 new test cases covering double-quoted, single-quoted, mismatched, empty, and partial quote scenarios
- **`docs/adr/ADR-021-quoted-timezone-values.md`**: Documents the decision, scope, and alternatives
- **README.md**, **DST_HANDLING.md**, **TROUBLESHOOTING.md**, **COOKBOOK.md**: Updated with quoted timezone examples

## What's supported

| Input | Result |
|-------|--------|
| `TZ="UTC" * * * * *` | Parsed as `UTC` |
| `TZ='America/New_York' 0 5 * * *` | Parsed as `America/New_York` |
| `CRON_TZ="Asia/Tokyo" 30 4 * * *` | Parsed as `Asia/Tokyo` |
| `TZ=UTC * * * * *` | Still works (backwards-compatible) |

## What's NOT supported (by design)

| Input | Result | Rationale |
|-------|--------|-----------|
| `TZ="America/New York" ...` | Error | IANA names never contain spaces |
| `TZ="UTC' ...` | Error | Mismatched quotes rejected |
| `TZ="" ...` | Error | Empty timezone after stripping |

## Test plan

- [x] 14 new test cases in `TestTimezoneQuotedValues`
- [x] All existing timezone tests pass (zero regressions)
- [x] Full test suite passes
- [x] Pre-push hooks pass (lint, vulncheck, tests)