### PR TITLE
fix(ci): resolve SLSA provenance race condition and scorecard compliance

### DIFF
--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -56,12 +56,12 @@ jobs:
         run: |
           cd release-assets
           # Generate SHA256 for all release assets
-          if ls * 1> /dev/null 2>&1; then
-            sha256sum * > ../provenance-subjects.txt
+          if ls ./* 1> /dev/null 2>&1; then
+            sha256sum ./* > ../provenance-subjects.txt
             cat ../provenance-subjects.txt
 
             # Create base64 encoded subjects for SLSA
-            SUBJECTS=$(cat ../provenance-subjects.txt | awk '{print "{\"name\":\""$2"\",\"digest\":{\"sha256\":\""$1"\"}}"}' | jq -s -c '.')
+            SUBJECTS=$(awk '{print "{\"name\":\""$2"\",\"digest\":{\"sha256\":\""$1"\"}}"}' ../provenance-subjects.txt | jq -s -c '.')
             # Base64 encode for the reusable workflow
             SUBJECTS_BASE64=$(echo "$SUBJECTS" | base64 -w0)
             echo "subjects=$SUBJECTS_BASE64" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Fixes the OpenSSF Scorecard warning: "release artifact does not have provenance" for all releases.

**Root cause**: The SLSA Provenance workflow was triggered on `release: published`, which fires *before* the Release workflow uploads assets. The prepare job found no assets to hash, causing the provenance generation to be skipped every time.

**Evidence**: All recent runs show `Generate SLSA Provenance: skipped` and logs show "No assets to hash".

## Changes

### Workflow fix (`slsa-provenance.yml`)
- **Trigger**: `release: published` → `workflow_run: completed` (runs after Release workflow)
- **Guard**: Only runs when Release workflow succeeds
- **Tag resolution**: Derives tag from `workflow_run.head_branch` instead of `release.tag_name`
- **Filename**: `source-provenance.json` → `source-provenance.intoto.jsonl` (scorecard expects `*.intoto.jsonl`)
- **Security**: Expression interpolation in heredoc replaced with env vars

### Retroactive fix (already applied)
- Uploaded `source-provenance.intoto.jsonl` to releases v0.9.1 through v0.13.0

## Test plan

- [x] Verified all 5 releases now have `source-provenance.intoto.jsonl` asset
- [ ] Next release will verify the workflow_run trigger works end-to-end
- [ ] Re-run scorecard after merge to confirm warnings resolved