### PR TITLE
chore: add SPDX headers and DCO enforcement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,43 @@ fix(scheduler): handle DST transitions correctly
 docs: update README with new examples
 ```
 
+### Developer Certificate of Origin (DCO)
+
+This project requires all contributions to be signed off under the
+[Developer Certificate of Origin (DCO)](https://developercertificate.org/).
+The DCO is a lightweight agreement that certifies you wrote or have the right
+to submit the code you are contributing.
+
+Every commit must contain a `Signed-off-by` trailer matching the commit author,
+for example:
+
+```
+feat(parser): add timezone alias support
+
+Signed-off-by: Jane Doe <jane@example.com>
+```
+
+Add it automatically by passing `-s` (or `--signoff`) to `git commit`:
+
+```bash
+git commit -s -m "feat(parser): add timezone alias support"
+```
+
+The project's [lefthook](https://github.com/evilmartians/lefthook) git hooks
+will automatically add the `Signed-off-by` trailer via a `prepare-commit-msg`
+hook and verify its presence in the `commit-msg` hook. If you prefer not to use
+lefthook, please remember to sign off manually.
+
+If you have already made commits without the sign-off, you can amend them:
+
+```bash
+# Amend the last commit
+git commit --amend -s --no-edit
+
+# Rebase and sign off all commits on your branch
+git rebase --signoff main
+```
+
 ### Testing
 
 - Write tests for new functionality

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cron
 
 import (

--- a/chain.go
+++ b/chain.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT.
+
 package cron
 
 import (

--- a/chain_test.go
+++ b/chain_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cron
 
 import (

--- a/clock.go
+++ b/clock.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT.
+
 package cron
 
 import (

--- a/clock_test.go
+++ b/clock_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cron
 
 import (

--- a/constantdelay.go
+++ b/constantdelay.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT.
+
 package cron
 
 import "time"

--- a/constantdelay_test.go
+++ b/constantdelay_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cron
 
 import (

--- a/cron.go
+++ b/cron.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT.
+
 package cron
 
 import (

--- a/cron_test.go
+++ b/cron_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cron
 
 import (

--- a/doc.go
+++ b/doc.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT.
+
 /*
 Package cron implements a cron spec parser and job runner.
 

--- a/example_test.go
+++ b/example_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cron_test
 
 import (

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cron
 
 import (

--- a/hash_test.go
+++ b/hash_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cron
 
 import (

--- a/heap.go
+++ b/heap.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT.
+
 package cron
 
 import (

--- a/heap_test.go
+++ b/heap_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cron
 
 import (

--- a/introspect.go
+++ b/introspect.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT.
+
 package cron
 
 import "time"

--- a/introspect_test.go
+++ b/introspect_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cron
 
 import (

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -51,6 +51,23 @@ pre-push:
     - name: vulncheck
       run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
 
+prepare-commit-msg:
+  jobs:
+    - name: add-signoff
+      run: |
+        # Auto-add Signed-off-by trailer if not already present.
+        # {1} is the commit message file path provided by git.
+        MSG_FILE="{1}"
+        SIGNOFF="Signed-off-by: $(git config user.name) <$(git config user.email)>"
+        if ! grep -qF "$SIGNOFF" "$MSG_FILE"; then
+          # Add a blank line before the trailer if the file doesn't end with one
+          if [ -n "$(tail -c1 "$MSG_FILE")" ]; then
+            echo "" >> "$MSG_FILE"
+          fi
+          echo "" >> "$MSG_FILE"
+          echo "$SIGNOFF" >> "$MSG_FILE"
+        fi
+
 commit-msg:
   jobs:
     - name: conventional-commit
@@ -60,5 +77,20 @@ commit-msg:
           echo "Error: Commit message must follow Conventional Commits format"
           echo "Format: type(scope): description"
           echo "Types: feat, fix, docs, style, refactor, test, chore, perf, ci, build, revert"
+          exit 1
+        fi
+
+    - name: dco-signoff
+      run: |
+        # Verify that every commit has a Signed-off-by trailer (DCO requirement).
+        MSG=$(cat {1})
+        if ! echo "$MSG" | grep -qE "^Signed-off-by: .+ <.+>"; then
+          echo "Error: Commit message must contain a DCO sign-off."
+          echo "Expected trailer: Signed-off-by: Your Name <your@email>"
+          echo ""
+          echo "Add it with: git commit -s"
+          echo "Or amend:    git commit --amend -s --no-edit"
+          echo ""
+          echo "See https://developercertificate.org/ for details."
           exit 1
         fi

--- a/logger.go
+++ b/logger.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT.
+
 package cron
 
 import (

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cron
 
 import (

--- a/max_concurrent_test.go
+++ b/max_concurrent_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cron
 
 import (

--- a/max_entries_test.go
+++ b/max_entries_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cron
 
 import (

--- a/missed.go
+++ b/missed.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT.
+
 package cron
 
 import "time"

--- a/missed_test.go
+++ b/missed_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cron
 
 import (

--- a/observability.go
+++ b/observability.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT.
+
 package cron
 
 import (

--- a/observability_test.go
+++ b/observability_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cron
 
 import (

--- a/option.go
+++ b/option.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT.
+
 package cron
 
 import (

--- a/option_capacity_test.go
+++ b/option_capacity_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cron
 
 import (

--- a/option_test.go
+++ b/option_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cron
 
 import (

--- a/parser.go
+++ b/parser.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT.
+
 package cron
 
 import (

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cron
 
 import (

--- a/realtime_test.go
+++ b/realtime_test.go
@@ -1,5 +1,7 @@
 //go:build integration
 
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
 package cron
 
 import (

--- a/retry.go
+++ b/retry.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT.
+
 package cron
 
 import (

--- a/retry_observability_test.go
+++ b/retry_observability_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cron
 
 import (

--- a/retry_test.go
+++ b/retry_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cron
 
 import (

--- a/spec.go
+++ b/spec.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT.
+
 package cron
 
 import "time"

--- a/spec_test.go
+++ b/spec_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cron
 
 import (

--- a/stress_test.go
+++ b/stress_test.go
@@ -1,5 +1,7 @@
 //go:build integration
 
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
 package cron
 
 import (

--- a/triggered.go
+++ b/triggered.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT.
+
 package cron
 
 import "time"

--- a/triggered_test.go
+++ b/triggered_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cron
 
 import (

--- a/validate.go
+++ b/validate.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT.
+
 package cron
 
 import (

--- a/validate_test.go
+++ b/validate_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cron
 
 import (

--- a/workflow.go
+++ b/workflow.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT.
+
 package cron
 
 import (

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cron
 
 import (

--- a/year_test.go
+++ b/year_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cron
 
 import (


### PR DESCRIPTION
## Summary
- Add SPDX copyright and MIT license headers to all 44 Go source files
- Add DCO enforcement via lefthook hooks (auto sign-off + verification)
- Supports OpenSSF Best Practices Silver/Gold badge criteria

## Test plan
- [ ] Verify SPDX headers present in Go files
- [ ] Verify lefthook DCO hooks work