### PR TITLE
fix: SLSA provenance format and flaky example test

### DIFF
--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -60,10 +60,9 @@ jobs:
             sha256sum ./* > ../provenance-subjects.txt
             cat ../provenance-subjects.txt
 
-            # Create base64 encoded subjects for SLSA
-            SUBJECTS=$(awk '{print "{\"name\":\""$2"\",\"digest\":{\"sha256\":\""$1"\"}}"}' ../provenance-subjects.txt | jq -s -c '.')
-            # Base64 encode for the reusable workflow
-            SUBJECTS_BASE64=$(echo "$SUBJECTS" | base64 -w0)
+            # Base64 encode raw sha256sum output for the SLSA reusable workflow
+            # (generator expects "HASH  FILENAME\n" format, NOT JSON array)
+            SUBJECTS_BASE64=$(base64 -w0 < ../provenance-subjects.txt)
             echo "subjects=$SUBJECTS_BASE64" >> "$GITHUB_OUTPUT"
             echo "has_subjects=true" >> "$GITHUB_OUTPUT"
           else
@@ -86,6 +85,7 @@ jobs:
     with:
       base64-subjects: ${{ needs.prepare.outputs.subjects }}
       upload-assets: true
+      private-repository: true  # Workaround: generator falsely detects public repos as private
 
   # Third job: Generate source attestation
   source-attestation:

--- a/example_test.go
+++ b/example_test.go
@@ -279,6 +279,7 @@ func ExampleCron_Entries() {
 	c.AddFunc("0 0 * * *", func() { fmt.Println("daily") })
 
 	c.Start()
+	defer c.Stop()
 
 	// Get all entries
 	entries := c.Entries()
@@ -296,6 +297,7 @@ func ExampleCron_Remove() {
 	})
 
 	c.Start()
+	defer c.Stop()
 
 	// Remove the job using its ID
 	c.Remove(entryID)
@@ -1132,7 +1134,7 @@ func ExampleWithRunOnce_withRunImmediately() {
 // The entry is removed after dispatch, even if the job panics.
 func ExampleWithRunOnce_withRecover() {
 	c := cron.New(cron.WithChain(
-		cron.Recover(cron.DefaultLogger),
+		cron.Recover(cron.DiscardLogger),
 	))
 
 	done := make(chan struct{})


### PR DESCRIPTION
## Summary
- Fix SLSA provenance workflow using wrong base64-subjects format (JSON array instead of raw sha256sum)
- Add `private-repository: true` workaround for false private repo detection
- Fix flaky `ExampleWithRunOnce_withRecover` on Windows (panic log bleeding into stdout)
- Add missing `defer c.Stop()` in `ExampleCron_Entries` and `ExampleCron_Remove`

## Root causes

**SLSA** ([run 22817283096](https://github.com/netresearch/go-cron/actions/runs/22817283096)): Two issues:
1. `base64-subjects` was JSON array format but generator expects raw `sha256sum` output (`HASH  FILENAME\n`)
2. Generator falsely detects public repo as private, halting to avoid leaking repo name to transparency log

**Example test** ([run 22818724108](https://github.com/netresearch/go-cron/actions/runs/22818724108/job/66187970920)): `Recover(cron.DefaultLogger)` logs panic recovery to stdout (DefaultLogger writes to os.Stdout), which gets captured by Go's example test output comparison. On Windows, this interleaves with the expected output. Fixed by using `DiscardLogger` since the test only verifies entry removal, not log output.

## Test plan
- [ ] CI passes on all platforms including Windows
- [ ] SLSA provenance workflow succeeds on next release