### PR TITLE
fix: hash expression pre-check false positive on day names containing H

### DIFF
--- a/hash_test.go
+++ b/hash_test.go
@@ -275,6 +275,29 @@ func TestWithHashKey(t *testing.T) {
 	}
 }
 
+// TestDayNameWithH tests that day names containing "H" (e.g. THU) are not
+// mistaken for hash expressions when the Hash option is not enabled.
+func TestDayNameWithH(t *testing.T) {
+	tests := []struct {
+		name string
+		spec string
+	}{
+		{"THU in standard parse", "0 0 * * THU"},
+		{"Thu mixed case", "0 0 * * Thu"},
+		{"THU with other days", "0 0 * * MON,THU,FRI"},
+		{"THU in range", "0 0 * * MON-THU"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseStandard(tt.spec)
+			if err != nil {
+				t.Errorf("ParseStandard(%q) unexpected error: %v", tt.spec, err)
+			}
+		})
+	}
+}
+
 // TestHashFieldConcurrent tests concurrent access with hash fields.
 func TestHashFieldConcurrent(t *testing.T) {
 	parser := NewParser(Minute | Hour | Dom | Month | Dow | Descriptor | Hash)

--- a/parser.go
+++ b/parser.go
@@ -450,15 +450,8 @@ func (p Parser) parse(spec string) (Schedule, error) {
 		return nil, err
 	}
 
-	// Check if any field contains H expression
 	hashEnabled := p.options&Hash != 0
-	hasHashExpr := false
-	for _, f := range fields {
-		if strings.Contains(f, "H") {
-			hasHashExpr = true
-			break
-		}
-	}
+	hasHashExpr := containsHashExpr(fields)
 
 	// Validate hash requirements
 	if hasHashExpr {
@@ -566,6 +559,21 @@ func (p Parser) parseDowField(fieldStr string, hashEnabled bool) (uint64, []DowC
 		bits, err := getFieldWithHash(fieldStr, dow, p.hashKey, hashEnabled)
 		return NormalizeDOW(bits), nil, err
 	}
+}
+
+// containsHashExpr reports whether any field contains a hash expression.
+// It checks HasPrefix on each comma-separated part rather than Contains on the
+// whole field, because named fields like day-of-week names (e.g. "THU") contain "H"
+// but are not hash expressions. Hash expressions always start with "H" (e.g. H, H/5, H(0-30)).
+func containsHashExpr(fields []string) bool {
+	for _, f := range fields {
+		for part := range strings.SplitSeq(f, ",") {
+			if strings.HasPrefix(part, "H") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // normalizeFields takes a subset set of the time fields and returns the full set


### PR DESCRIPTION
The hash expression detection in parser.go used strings.Contains(f, "H") to check if any field contains a hash expression. This incorrectly matched day-of-week names like "THU" (Thursday) which contain the letter "H", causing valid standard cron expressions like "0 0 * * THU" to fail with "h expressions require hash option to be enabled".

Hash expressions always start with "H" (e.g. H, H/5, H(0-30)), so the fix checks HasPrefix on each comma-separated part of each field instead of Contains on the whole field. This is consistent with how getRangeWithHash() already correctly uses HasPrefix.

Fixes #346

## Description

Brief description of the changes.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #346

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run `make verify` and all checks pass
- [x] I have added tests covering my changes
- [ ] I have updated documentation as needed
- [x] My commits follow conventional commit format

## Testing

unit tests
## Additional Notes

Any additional information reviewers should know.
