### PR TITLE
feat: export RunJob helper for custom job wrappers

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -114,8 +114,9 @@ func toError(v any) error {
 	return fmt.Errorf("%v", v)
 }
 
-// runJob executes a job, passing ctx if it implements JobWithContext.
-func runJob(ctx context.Context, j Job) {
+// RunJob executes a job, passing ctx if it implements JobWithContext.
+// This is a helper to be used in job wrapper.
+func RunJob(ctx context.Context, j Job) {
 	if jc, ok := j.(JobWithContext); ok {
 		jc.RunWithContext(ctx)
 	} else {
@@ -154,7 +155,7 @@ func (r *recoverJob) RunWithContext(ctx context.Context) {
 			}
 		}
 	}()
-	runJob(ctx, r.inner)
+	RunJob(ctx, r.inner)
 }
 
 // Recover panics in wrapped jobs and log them with the provided logger.
@@ -213,7 +214,7 @@ func (d *delayJob) RunWithContext(ctx context.Context) {
 	if dur := time.Since(start); dur > d.logThreshold {
 		d.logger.Info("delay", "duration", dur)
 	}
-	runJob(ctx, d.inner)
+	RunJob(ctx, d.inner)
 }
 
 // DelayIfStillRunning serializes jobs, delaying subsequent runs until the
@@ -245,7 +246,7 @@ func (s *skipJob) RunWithContext(ctx context.Context) {
 	select {
 	case v := <-s.ch:
 		defer func() { s.ch <- v }()
-		runJob(ctx, s.inner)
+		RunJob(ctx, s.inner)
 	default:
 		s.logger.Info("skip")
 	}
@@ -394,7 +395,7 @@ func (t *timeoutJob) RunWithContext(ctx context.Context) {
 	var panicVal any
 	go func() {
 		defer close(done)
-		panicVal = safeExecute(func() { runJob(ctx, t.inner) })
+		panicVal = safeExecute(func() { RunJob(ctx, t.inner) })
 	}()
 
 	timer := time.NewTimer(t.timeout)
@@ -499,7 +500,7 @@ func (t *timeoutContextJob) RunWithContext(ctx context.Context) {
 
 	go func() {
 		defer close(done)
-		panicVal = safeExecute(func() { runJob(ctx, t.inner) })
+		panicVal = safeExecute(func() { RunJob(ctx, t.inner) })
 	}()
 
 	select {
@@ -552,7 +553,7 @@ func (j *jitterJob) RunWithContext(ctx context.Context) {
 		jitter := time.Duration(rand.Int64N(int64(j.maxJitter)))
 		time.Sleep(jitter)
 	}
-	runJob(ctx, j.inner)
+	RunJob(ctx, j.inner)
 }
 
 // Jitter adds a random delay before job execution to prevent thundering herd.
@@ -606,7 +607,7 @@ func (j *jitterLogJob) RunWithContext(ctx context.Context) {
 		j.logger.Info("jitter", "delay", jitter, "max", j.maxJitter)
 		time.Sleep(jitter)
 	}
-	runJob(ctx, j.inner)
+	RunJob(ctx, j.inner)
 }
 
 // JitterWithLogger is like Jitter but logs the applied delay.
@@ -641,7 +642,7 @@ func (m *maxConcurrentJob) RunWithContext(ctx context.Context) {
 	select {
 	case m.sem <- struct{}{}: // acquire slot
 		defer func() { <-m.sem }()
-		runJob(ctx, m.inner)
+		RunJob(ctx, m.inner)
 	case <-ctx.Done():
 		return // context canceled while waiting for slot
 	}
@@ -713,7 +714,7 @@ func (m *maxConcurrentSkipJob) RunWithContext(ctx context.Context) {
 	select {
 	case m.sem <- struct{}{}: // try to acquire slot
 		defer func() { <-m.sem }()
-		runJob(ctx, m.inner)
+		RunJob(ctx, m.inner)
 	default:
 		m.logger.Info("skip", "reason", "max concurrent reached")
 	}

--- a/chain.go
+++ b/chain.go
@@ -114,8 +114,9 @@ func toError(v any) error {
 	return fmt.Errorf("%v", v)
 }
 
-// RunJob executes a job, passing ctx if it implements JobWithContext.
-// This is a helper to be used in job wrapper.
+// RunJob executes the job. If the job implements JobWithContext, it is called
+// with the provided context. Otherwise, its Run method is called.
+// This is a helper intended for use in custom job wrappers.
 func RunJob(ctx context.Context, j Job) {
 	if jc, ok := j.(JobWithContext); ok {
 		jc.RunWithContext(ctx)

--- a/chain_test.go
+++ b/chain_test.go
@@ -33,6 +33,26 @@ func appendingWrapper(slice *[]int, value int) JobWrapper {
 	}
 }
 
+func TestRunJob_PlainJob(t *testing.T) {
+	var called bool
+	j := FuncJob(func() { called = true })
+	RunJob(context.Background(), j)
+	if !called {
+		t.Fatal("RunJob did not call Run on plain Job")
+	}
+}
+
+func TestRunJob_JobWithContext(t *testing.T) {
+	var got context.Context
+	j := FuncJobWithContext(func(ctx context.Context) { got = ctx })
+	type ctxKey struct{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, "val")
+	RunJob(ctx, j)
+	if got != ctx {
+		t.Fatal("RunJob did not pass context to RunWithContext")
+	}
+}
+
 func TestChain(t *testing.T) {
 	var nums []int
 	var (

--- a/cron.go
+++ b/cron.go
@@ -1347,12 +1347,7 @@ func (c *Cron) startJobWithExecution(entryCtx context.Context, entryRunning *job
 			defer func() {
 				recovered = recover()
 			}()
-			// Check if the job supports context and call appropriate method
-			if jc, ok := wrappedJob.(JobWithContext); ok {
-				jc.RunWithContext(runCtx)
-			} else {
-				wrappedJob.Run()
-			}
+			RunJob(runCtx, wrappedJob)
 		}()
 		duration := c.clock.Now().Sub(start)
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1781,6 +1781,16 @@ All chain wrappers implement `JobWithContext` and propagate the incoming context
 to inner jobs that also implement `JobWithContext`. This means per-entry context
 flows through the entire wrapper chain to context-aware jobs.
 
+#### func RunJob
+
+```go
+func RunJob(ctx context.Context, j Job)
+```
+
+RunJob executes the job. If the job implements `JobWithContext`, it is called
+with the provided context. Otherwise, its `Run` method is called.
+This is a helper intended for use in custom `JobWrapper` implementations.
+
 #### func Recover
 
 ```go

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -607,15 +607,27 @@ c := cron.New(cron.WithLogger(MyLogger{}))
 
 ### Custom Job Wrapper
 
+Use `RunJob` to dispatch the inner job so that context-aware jobs
+(`JobWithContext`) receive the context automatically:
+
 ```go
 func MetricsWrapper(m *metrics.Registry) cron.JobWrapper {
     return func(j cron.Job) cron.Job {
-        return cron.FuncJob(func() {
-            start := time.Now()
-            j.Run()
-            m.RecordDuration("cron.job.duration", time.Since(start))
-        })
+        return &metricsJob{inner: j, metrics: m}
     }
+}
+
+type metricsJob struct {
+    inner   cron.Job
+    metrics *metrics.Registry
+}
+
+func (m *metricsJob) Run() { m.RunWithContext(context.Background()) }
+
+func (m *metricsJob) RunWithContext(ctx context.Context) {
+    start := time.Now()
+    cron.RunJob(ctx, m.inner)
+    m.metrics.RecordDuration("cron.job.duration", time.Since(start))
 }
 
 c := cron.New(cron.WithChain(MetricsWrapper(registry)))


### PR DESCRIPTION
## Summary

- Export `runJob` as `RunJob` so custom job wrappers can dispatch to `JobWithContext` / plain `Job` without reimplementing the type-switch
- Consolidate the duplicated dispatch logic in `startJobWithExecution` (`cron.go`) to use `RunJob`
- Add unit tests covering both execution paths (plain `Job` and `JobWithContext`)

## Type of Change

- [x] New feature (non-breaking addition)

## Related Issues

Closes #355

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run `make verify` and all checks pass
- [x] I have added tests covering my changes
- [x] My commits follow conventional commit format

## Testing

- `TestRunJob_PlainJob` — verifies `Run()` is called for plain `Job`
- `TestRunJob_JobWithContext` — verifies `RunWithContext(ctx)` is called with the correct context
- Full test suite passes with `-race`