### PR TITLE
fix(clock): resolve missed-wakeup race in FakeClock BlockUntil

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -66,7 +66,7 @@ func (r *realTimer) Reset(d time.Duration) bool {
 // It allows advancing time manually and fires timers deterministically.
 type FakeClock struct {
 	mu     sync.Mutex
-	cond   sync.Cond
+	cond   *sync.Cond
 	now    time.Time
 	timers timerHeap
 }
@@ -77,7 +77,8 @@ func NewFakeClock(t time.Time) *FakeClock {
 		now:    t,
 		timers: make(timerHeap, 0),
 	}
-	f.cond = sync.Cond{L: &f.mu}
+
+	f.cond = sync.NewCond(&f.mu)
 	return f
 }
 

--- a/clock.go
+++ b/clock.go
@@ -65,18 +65,20 @@ func (r *realTimer) Reset(d time.Duration) bool {
 // FakeClock provides a controllable clock for testing.
 // It allows advancing time manually and fires timers deterministically.
 type FakeClock struct {
-	mu      sync.Mutex
-	now     time.Time
-	timers  timerHeap
-	waiters []chan struct{}
+	mu     sync.Mutex
+	cond   sync.Cond
+	now    time.Time
+	timers timerHeap
 }
 
 // NewFakeClock creates a new FakeClock initialized to the given time.
 func NewFakeClock(t time.Time) *FakeClock {
-	return &FakeClock{
+	f := &FakeClock{
 		now:    t,
 		timers: make(timerHeap, 0),
 	}
+	f.cond = sync.Cond{L: &f.mu}
+	return f
 }
 
 // Now returns the fake clock's current time.
@@ -135,27 +137,10 @@ func (f *FakeClock) Advance(d time.Duration) {
 // This is useful for synchronizing tests with timer creation.
 func (f *FakeClock) BlockUntil(n int) {
 	f.mu.Lock()
-
-	if len(f.timers) >= n {
-		f.mu.Unlock()
-		return
+	for len(f.timers) < n {
+		f.cond.Wait()
 	}
-
-	waiter := make(chan struct{})
-	f.waiters = append(f.waiters, waiter)
 	f.mu.Unlock()
-
-	for {
-		<-waiter
-		f.mu.Lock()
-		if len(f.timers) >= n {
-			f.mu.Unlock()
-			return
-		}
-		waiter = make(chan struct{})
-		f.waiters = append(f.waiters, waiter)
-		f.mu.Unlock()
-	}
 }
 
 // TimerCount returns the number of active timers.
@@ -171,11 +156,11 @@ func (f *FakeClock) TimerCount() int {
 func (f *FakeClock) fireExpiredTimers() {
 	for len(f.timers) > 0 && !f.timers[0].deadline.After(f.now) {
 		t := heap.Pop(&f.timers).(*fakeTimer) //nolint:forcetypeassert,errcheck // heap.Interface contract guarantees type
+		t.fired = true
 		if !t.stopped {
 			select {
 			case t.ch <- f.now:
 			default:
-				// Channel full, timer already fired
 			}
 		}
 	}
@@ -184,13 +169,7 @@ func (f *FakeClock) fireExpiredTimers() {
 // notifyWaiters wakes up any goroutines waiting in BlockUntil.
 // Must be called with f.mu held.
 func (f *FakeClock) notifyWaiters() {
-	for _, w := range f.waiters {
-		select {
-		case w <- struct{}{}:
-		default:
-		}
-	}
-	f.waiters = nil
+	f.cond.Broadcast()
 }
 
 // removeTimer removes a timer from the heap using O(log n) indexed removal.
@@ -205,6 +184,7 @@ type fakeTimer struct {
 	deadline  time.Time
 	ch        chan time.Time
 	stopped   bool
+	fired     bool
 	heapIndex int // position in timerHeap, -1 if not in heap
 }
 
@@ -229,8 +209,9 @@ func (t *fakeTimer) Reset(d time.Duration) bool {
 	t.clock.mu.Lock()
 	defer t.clock.mu.Unlock()
 
-	wasActive := !t.stopped && t.clock.removeTimer(t)
+	wasActive := !t.fired && !t.stopped && t.clock.removeTimer(t)
 
+	t.fired = false
 	t.stopped = false
 	t.deadline = t.clock.now.Add(d)
 

--- a/clock.go
+++ b/clock.go
@@ -157,7 +157,6 @@ func (f *FakeClock) TimerCount() int {
 func (f *FakeClock) fireExpiredTimers() {
 	for len(f.timers) > 0 && !f.timers[0].deadline.After(f.now) {
 		t := heap.Pop(&f.timers).(*fakeTimer) //nolint:forcetypeassert,errcheck // heap.Interface contract guarantees type
-		t.fired = true
 		if !t.stopped {
 			select {
 			case t.ch <- f.now:
@@ -185,7 +184,6 @@ type fakeTimer struct {
 	deadline  time.Time
 	ch        chan time.Time
 	stopped   bool
-	fired     bool
 	heapIndex int // position in timerHeap, -1 if not in heap
 }
 
@@ -210,9 +208,8 @@ func (t *fakeTimer) Reset(d time.Duration) bool {
 	t.clock.mu.Lock()
 	defer t.clock.mu.Unlock()
 
-	wasActive := !t.fired && !t.stopped && t.clock.removeTimer(t)
+	wasActive := !t.stopped && t.clock.removeTimer(t)
 
-	t.fired = false
 	t.stopped = false
 	t.deadline = t.clock.now.Add(d)
 

--- a/clock_test.go
+++ b/clock_test.go
@@ -299,6 +299,32 @@ func TestFakeClockBlockUntil(t *testing.T) {
 	}
 }
 
+// TestFakeClockBlockUntilRace is a regression test for the missed-wakeup race
+// that existed when BlockUntil used channels instead of sync.Cond. The old
+// implementation could hang indefinitely if a timer was created between the
+// mutex unlock and the channel receive in BlockUntil.
+func TestFakeClockBlockUntilRace(t *testing.T) {
+	for range 100 {
+		clock := NewFakeClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+
+		done := make(chan struct{})
+		go func() {
+			clock.BlockUntil(1)
+			close(done)
+		}()
+
+		// Create timer concurrently — previously could race with BlockUntil
+		clock.NewTimer(time.Second)
+
+		select {
+		case <-done:
+			// BlockUntil returned — no missed wakeup
+		case <-time.After(time.Second):
+			t.Fatal("BlockUntil hung — missed wakeup regression")
+		}
+	}
+}
+
 func TestFakeClockTimerCount(t *testing.T) {
 	start := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
 	clock := NewFakeClock(start)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -180,7 +180,7 @@ Abstraction for time operations:
 │                     │     │                             │
 │  Now() → time.Now() │     │  now      time.Time         │
 │  NewTimer() →       │     │  timers   timerHeap         │
-│    time.NewTimer()  │     │  waiters  []chan struct{}   │
+│    time.NewTimer()  │     │  cond     *sync.Cond        │
 └─────────────────────┘     │                             │
                             │  Advance(d) → fire timers   │
                             │  Set(t) → jump to time      │
@@ -544,10 +544,10 @@ func TestScheduledJob(t *testing.T) {
 
 ```go
 type FakeClock struct {
-    mu      sync.Mutex
-    now     time.Time
-    timers  timerHeap         // Min-heap of fake timers
-    waiters []chan struct{}   // BlockUntil waiters
+    mu     sync.Mutex
+    cond   *sync.Cond        // BlockUntil waiters (Broadcast on timer add)
+    now    time.Time
+    timers timerHeap          // Min-heap of fake timers
 }
 
 type fakeTimer struct {


### PR DESCRIPTION
## Summary

- Replace channel-based `BlockUntil` waiter list with `sync.Cond` to eliminate a missed-wakeup race where notifications could be lost between mutex unlock and channel receive
- Remove redundant `fired` field from `fakeTimer` — active state is already tracked by heap presence
- Add regression stress test exercising the concurrent interleaving that previously caused hangs
- Update ARCHITECTURE.md to reflect the `sync.Cond` change

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Related Issues

Fixes #357

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run `make verify` and all checks pass
- [x] I have added tests covering my changes
- [x] I have updated documentation as needed
- [x] My commits follow conventional commit format

## Testing

- `TestFakeClockBlockUntilRace` — 100 iterations of concurrent `BlockUntil(1)` vs `NewTimer` with race detector
- Full test suite passes with `-race` (5 consecutive runs)