### PR TITLE
chore(ci): use @main for org reusable workflows

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -11,4 +11,4 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@eafa800ce23f3b52e0863ab042a8ba0801e97cab
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,6 @@ jobs:
       contents: read
       security-events: write
       actions: read
-    uses: netresearch/.github/.github/workflows/codeql.yml@eafa800ce23f3b52e0863ab042a8ba0801e97cab
+    uses: netresearch/.github/.github/workflows/codeql.yml@main
     with:
       languages: go

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,6 +12,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: netresearch/.github/.github/workflows/dependency-review.yml@eafa800ce23f3b52e0863ab042a8ba0801e97cab
+    uses: netresearch/.github/.github/workflows/dependency-review.yml@main
     with:
       fail-on-severity: high

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -13,4 +13,4 @@ permissions:
 
 jobs:
   quality:
-    uses: netresearch/.github/.github/workflows/pr-quality.yml@eafa800ce23f3b52e0863ab042a8ba0801e97cab
+    uses: netresearch/.github/.github/workflows/pr-quality.yml@main

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,4 +17,4 @@ jobs:
       id-token: write
       contents: read
       actions: read
-    uses: netresearch/.github/.github/workflows/scorecard.yml@eafa800ce23f3b52e0863ab042a8ba0801e97cab
+    uses: netresearch/.github/.github/workflows/scorecard.yml@main


### PR DESCRIPTION
## Summary

- Replace SHA-pinned references to `netresearch/.github` reusable workflows with `@main`
- Affects: `pr-quality`, `scorecard`, `codeql`, `dependency-review`, `auto-merge-deps`
- SHA-pinning org-internal workflows we control requires a PR in every consuming repo on each update — `@main` keeps them in sync automatically

## Test plan

- [ ] CI passes with `@main` references
- [ ] Auto-Approve now skips for fork PRs (picks up netresearch/.github#13)