### PR TITLE
chore(deps): update toolchain to go1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/netresearch/go-cron
 
 go 1.25
 
-toolchain go1.25.5
+toolchain go1.26.2
 
 retract (
 	v1.3.0 // Retraction-only release; use v0.6.x


### PR DESCRIPTION
## Summary

- Bump toolchain directive from `go1.25.5` to `go1.26.2`
- Minimum `go 1.25` preserved for backwards compatibility
- No external dependencies to update (zero-dependency library)

## Test plan

- [ ] CI passes on both `1.25.x` and `1.26.x` matrices