### PR TITLE
ci: sync with netresearch/.github templates/go-lib

### DIFF
--- a/.github/workflows/check-template-drift.yml
+++ b/.github/workflows/check-template-drift.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   push:
     branches: [main]
+  merge_group:
 
 permissions: {}
 


### PR DESCRIPTION
Auto-opened by sync-template.sh. Brings this repo back into alignment with the canonical `go-lib` template in `netresearch/.github`.

To keep any diverging files, add their paths to `.github/template.yaml`'s `intentional-drift:` list before merging — otherwise the next sync run will revert them.