### PR TITLE
test(integration): tighten cleanup + poll-for-stable goroutine count

### DIFF
--- a/integration_realclock_test.go
+++ b/integration_realclock_test.go
@@ -85,9 +85,14 @@ func TestIntegrationStartStopNoGoroutineLeak(t *testing.T) {
 	}
 
 	c.Start()
-	// Idempotent safety net: if any assertion below fatals before the
-	// explicit Stop(), the deferred Stop() still drains the run loop.
-	defer c.Stop()
+	// Safety net for early t.Fatal paths only. Stop() always spawns a
+	// goroutine to wait on jobWaiter, so skip it when the explicit
+	// Stop() below has already run.
+	t.Cleanup(func() {
+		if c.IsRunning() {
+			c.Stop()
+		}
+	})
 	// Let the run loop actually schedule at least one tick.
 	time.Sleep(1200 * time.Millisecond)
 
@@ -268,10 +273,14 @@ func TestIntegrationContextCancelOnStop(t *testing.T) {
 	}
 
 	c.Start()
-	// Guard against early t.Fatal paths leaking the run-loop goroutine
-	// into subsequent tests; Stop() is idempotent so the explicit
-	// c.Stop() below still governs cancellation timing.
-	defer c.Stop()
+	// Safety net for early t.Fatal paths only. Stop() always spawns a
+	// goroutine to wait on jobWaiter, so skip it when the explicit
+	// Stop() below has already run.
+	t.Cleanup(func() {
+		if c.IsRunning() {
+			c.Stop()
+		}
+	})
 
 	// Wait for the job to actually start.
 	select {

--- a/integration_realclock_test.go
+++ b/integration_realclock_test.go
@@ -85,6 +85,9 @@ func TestIntegrationStartStopNoGoroutineLeak(t *testing.T) {
 	}
 
 	c.Start()
+	// Idempotent safety net: if any assertion below fatals before the
+	// explicit Stop(), the deferred Stop() still drains the run loop.
+	defer c.Stop()
 	// Let the run loop actually schedule at least one tick.
 	time.Sleep(1200 * time.Millisecond)
 
@@ -98,19 +101,41 @@ func TestIntegrationStartStopNoGoroutineLeak(t *testing.T) {
 	stopElapsed := time.Since(stopStart)
 	t.Logf("Stop() completed in %v (fired=%d)", stopElapsed, fired.Load())
 
-	// Allow scheduler goroutines a brief moment to fully unwind.
-	time.Sleep(100 * time.Millisecond)
-
-	// Verify no persistent goroutine leak. Allow a small +slack because
-	// the Go runtime may keep a few helper goroutines around.
-	after := runtime.NumGoroutine()
-	if after > baseline+2 {
+	// Poll until the goroutine count stabilizes at baseline instead of
+	// sampling a single point-in-time value. CI-side noise (GC helper
+	// goroutines, runtime timers, test-runner internals) can push the
+	// count transiently above baseline; requiring a run of consecutive
+	// stable samples absorbs that jitter without hiding real leaks.
+	const (
+		maxSamples   = 50
+		stableWindow = 5
+		sampleDelay  = 100 * time.Millisecond
+		slack        = 2
+	)
+	var (
+		stableFor int
+		after     int
+	)
+	for i := 0; i < maxSamples; i++ {
+		time.Sleep(sampleDelay)
+		after = runtime.NumGoroutine()
+		if after <= baseline+slack {
+			stableFor++
+			if stableFor >= stableWindow {
+				break
+			}
+		} else {
+			stableFor = 0
+		}
+	}
+	if stableFor < stableWindow {
 		buf := make([]byte, 1<<15)
 		n := runtime.Stack(buf, true)
-		t.Fatalf("goroutine leak: baseline=%d, after Stop=%d\n%s",
-			baseline, after, buf[:n])
+		t.Fatalf("goroutine leak: baseline=%d, after=%d never stabilized within %v\n%s",
+			baseline, after, time.Duration(maxSamples)*sampleDelay, buf[:n])
 	}
-	t.Logf("goroutine count baseline=%d after_stop=%d", baseline, after)
+	t.Logf("goroutine count baseline=%d after_stop=%d (stable for %d samples)",
+		baseline, after, stableFor)
 }
 
 // TestIntegrationMixedIntervalsCounts schedules two jobs (every 1s and
@@ -243,6 +268,10 @@ func TestIntegrationContextCancelOnStop(t *testing.T) {
 	}
 
 	c.Start()
+	// Guard against early t.Fatal paths leaking the run-loop goroutine
+	// into subsequent tests; Stop() is idempotent so the explicit
+	// c.Stop() below still governs cancellation timing.
+	defer c.Stop()
 
 	// Wait for the job to actually start.
 	select {


### PR DESCRIPTION
## Summary

Follow-up fixes for the two concerns raised in [#372](https://github.com/netresearch/go-cron/issues/372) (copilot-pull-request-reviewer follow-up from [#371](https://github.com/netresearch/go-cron/pull/371)). Both tests pass today but the patterns carried flakiness risk under heavier CI load.

1. **`TestIntegrationContextCancelOnStop`** and **`TestIntegrationStartStopNoGoroutineLeak`** now add \`defer c.Stop()\` immediately after \`c.Start()\`. \`Stop()\` is idempotent, so the explicit \`Stop()\` calls still govern cancellation timing; the defer only guards against early \`t.Fatal\` paths leaking the run-loop goroutine into subsequent tests in the same package.

2. **`TestIntegrationStartStopNoGoroutineLeak`**'s goroutine-leak check now polls \`runtime.NumGoroutine()\` until the count stays at or below \`baseline+2\` for 5 consecutive 100ms samples, rather than asserting against a single post-Stop sample. That absorbs CI-side jitter from GC helper goroutines, runtime timers, and test-runner internals without hiding real leaks — a genuine leak still fails because the count will not stabilize.

Closes [#372](https://github.com/netresearch/go-cron/issues/372).

## Test plan

- [x] \`go test -tags=integration -race -run 'TestIntegration(PerSecond|StartStop|ContextCancel)' ./...\` passes locally (7.6s).
- [x] \`TestIntegrationStartStopNoGoroutineLeak\` logs \`baseline=2 after_stop=2 (stable for 5 samples)\` — stable window reached on first pass.