### PR TITLE
fix(lint): extract repeated cron descriptors into constants

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -414,7 +414,7 @@ func (p Parser) ParseWithHashKey(spec, hashKey string) (Schedule, error) {
 // parse is the internal parsing logic, called by Parse.
 func (p Parser) parse(spec string) (Schedule, error) {
 	if len(spec) == 0 {
-		return nil, errors.New("empty spec string")
+		return nil, errors.New(emptySpecMessage)
 	}
 	if len(spec) > MaxSpecLength {
 		return nil, fmt.Errorf("spec too long: %d > %d", len(spec), MaxSpecLength)
@@ -1487,21 +1487,35 @@ func newDescriptorSchedule(hour, dom, month, dow uint64, loc *time.Location, max
 	}
 }
 
+// Cron descriptor keywords accepted by parseDescriptor.
+const (
+	descriptorYearly    = "@yearly"
+	descriptorAnnually  = "@annually"
+	descriptorMonthly   = "@monthly"
+	descriptorWeekly    = "@weekly"
+	descriptorDaily     = "@daily"
+	descriptorMidnight  = "@midnight"
+	descriptorHourly    = "@hourly"
+	descriptorTriggered = "@triggered"
+	descriptorManual    = "@manual"
+	descriptorNone      = "@none"
+)
+
 func parseDescriptor(descriptor string, loc *time.Location, minEveryInterval time.Duration, maxSearchYears int) (Schedule, error) {
 	// Normalize DOW bits so that both Sunday=0 and Sunday=7 are handled consistently
 	allDow := NormalizeDOW(all(dow))
 	switch descriptor {
-	case "@yearly", "@annually":
+	case descriptorYearly, descriptorAnnually:
 		return newDescriptorSchedule(1<<hours.min, 1<<dom.min, 1<<months.min, allDow, loc, maxSearchYears), nil
-	case "@monthly":
+	case descriptorMonthly:
 		return newDescriptorSchedule(1<<hours.min, 1<<dom.min, all(months), allDow, loc, maxSearchYears), nil
-	case "@weekly":
+	case descriptorWeekly:
 		return newDescriptorSchedule(1<<hours.min, all(dom), all(months), 1<<dow.min, loc, maxSearchYears), nil
-	case "@daily", "@midnight":
+	case descriptorDaily, descriptorMidnight:
 		return newDescriptorSchedule(1<<hours.min, all(dom), all(months), allDow, loc, maxSearchYears), nil
-	case "@hourly":
+	case descriptorHourly:
 		return newDescriptorSchedule(all(hours), all(dom), all(months), allDow, loc, maxSearchYears), nil
-	case "@triggered", "@manual", "@none":
+	case descriptorTriggered, descriptorManual, descriptorNone:
 		return TriggeredSchedule{}, nil
 	}
 

--- a/parser.go
+++ b/parser.go
@@ -1487,7 +1487,9 @@ func newDescriptorSchedule(hour, dom, month, dow uint64, loc *time.Location, max
 	}
 }
 
-// Cron descriptor keywords accepted by parseDescriptor.
+// Cron descriptor keywords accepted by parseDescriptor. The calendar and
+// trigger keywords are matched exactly; descriptorEvery is matched as a
+// prefix for "@every <duration>" expressions.
 const (
 	descriptorYearly    = "@yearly"
 	descriptorAnnually  = "@annually"
@@ -1496,6 +1498,7 @@ const (
 	descriptorDaily     = "@daily"
 	descriptorMidnight  = "@midnight"
 	descriptorHourly    = "@hourly"
+	descriptorEvery     = "@every "
 	descriptorTriggered = "@triggered"
 	descriptorManual    = "@manual"
 	descriptorNone      = "@none"
@@ -1519,9 +1522,8 @@ func parseDescriptor(descriptor string, loc *time.Location, minEveryInterval tim
 		return TriggeredSchedule{}, nil
 	}
 
-	const every = "@every "
-	if strings.HasPrefix(descriptor, every) {
-		duration, err := time.ParseDuration(descriptor[len(every):])
+	if strings.HasPrefix(descriptor, descriptorEvery) {
+		duration, err := time.ParseDuration(descriptor[len(descriptorEvery):])
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse duration %q: %w", descriptor, err)
 		}

--- a/validate.go
+++ b/validate.go
@@ -264,9 +264,8 @@ func (r *SpecAnalysis) analyzeSpec(spec string) {
 
 // analyzeDescriptor extracts information from descriptor-style specs.
 func (r *SpecAnalysis) analyzeDescriptor(descriptor string) {
-	const every = "@every "
-	if strings.HasPrefix(descriptor, every) {
-		durationStr := descriptor[len(every):]
+	if strings.HasPrefix(descriptor, descriptorEvery) {
+		durationStr := descriptor[len(descriptorEvery):]
 		if duration, err := time.ParseDuration(durationStr); err == nil {
 			r.Interval = duration
 		}
@@ -357,7 +356,8 @@ func getParserForOptions(options []ParseOption) Parser {
 	return NewParser(opts)
 }
 
-// emptySpecMessage is the error text used when a spec string is empty.
+// emptySpecMessage is the package-shared error text used when a spec string
+// is empty. It backs both ErrEmptySpec here and the parser.parse() error.
 const emptySpecMessage = "empty spec string"
 
 // ErrEmptySpec is returned when an empty spec string is provided.

--- a/validate.go
+++ b/validate.go
@@ -357,8 +357,11 @@ func getParserForOptions(options []ParseOption) Parser {
 	return NewParser(opts)
 }
 
+// emptySpecMessage is the error text used when a spec string is empty.
+const emptySpecMessage = "empty spec string"
+
 // ErrEmptySpec is returned when an empty spec string is provided.
-var ErrEmptySpec = &ValidationError{Message: "empty spec string"}
+var ErrEmptySpec = &ValidationError{Message: emptySpecMessage}
 
 // ValidationError represents a cron expression validation error.
 type ValidationError struct {


### PR DESCRIPTION
## Summary
- Scheduled CI on `main` has been failing on the `golangci-lint` job since the go-check template sync ([#378](https://github.com/netresearch/go-cron/pull/378)) enabled `goconst`.
- `goconst` flagged the repeated descriptor keywords (`@annually`, `@monthly`, `@weekly`, `@daily`, `@hourly`) in the `parseDescriptor` switch and the `"empty spec string"` message used in both `validate.go` and `parser.go`.
- Introduces named constants (`descriptor*`, `emptySpecMessage`) and uses them at the flagged sites. No behavior change.

## Verification
- `go build ./...` — clean
- `golangci-lint run ./...` — `0 issues.`
- `go test -run 'Descriptor|Parse|EmptySpec|Validate' ./...` — pass