### PR TITLE
feat: add DrainAndUpsertJob for windowless graceful reschedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Originally based on [robfig/cron](https://github.com/robfig/cron).
 
 ## [Unreleased]
 
+### Added
+- **`DrainAndUpsertJob`** ([PR#381]): windowless variant of `UpsertJob` for graceful
+  reschedule. Pauses the named entry, drains any in-flight invocation, swaps the
+  schedule and job, then restores the entry's prior paused state — closing the
+  narrow window in which the two-step `WaitForJobByName` → `UpsertJob` sequence
+  could let the old schedule fire once more between the wait and the
+  replacement. Composes existing serialized methods, so the drain never holds a
+  cron lock. Motivated by the
+  [weaviate object-TTL scheduler](https://github.com/weaviate/weaviate/pull/10477);
+  see [ADR-022](docs/adr/ADR-022-drain-and-upsert.md).
+
 ### Planned for v2
 - Context-aware Job interface with graceful shutdown support
 
@@ -403,6 +414,7 @@ Originally based on [robfig/cron](https://github.com/robfig/cron).
 [PR#259]: https://github.com/netresearch/go-cron/pull/259
 [PR#260]: https://github.com/netresearch/go-cron/pull/260
 [PR#261]: https://github.com/netresearch/go-cron/pull/261
+[PR#381]: https://github.com/netresearch/go-cron/pull/381
 [ADR-007]: docs/adr/ADR-007-nw-skip-invalid-days.md
 [ADRs]: docs/adr/
 [COOKBOOK]: docs/COOKBOOK.md
@@ -564,7 +576,7 @@ This fork includes all features from robfig/cron v3 plus:
    _, err := cron.ParseStandard("*/60 * * * *") // Error: step (60) must be less than range size (60)
    ```
 
-[Unreleased]: https://github.com/netresearch/go-cron/compare/v0.13.1...HEAD
+[Unreleased]: https://github.com/netresearch/go-cron/compare/v0.14.0...HEAD
 [0.13.1]: https://github.com/netresearch/go-cron/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/netresearch/go-cron/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/netresearch/go-cron/compare/v0.11.0...v0.12.0

--- a/README.md
+++ b/README.md
@@ -263,6 +263,15 @@ c.WaitForJobByName("my-job")  // Block until current execution finishes
 c.UpsertJob(newSpec, newJob, cron.WithName("my-job"))
 ```
 
+These two calls are not atomic — the old schedule can fire once in the gap
+between them. For a windowless reschedule, use `DrainAndUpsertJob`, which pauses
+the entry, drains the in-flight invocation, swaps schedule and job, and restores
+the prior paused state in one call:
+
+```go
+c.DrainAndUpsertJob(newSpec, newJob, cron.WithName("my-job"))
+```
+
 ## Pause/Resume
 
 Temporarily suspend individual entries without removing them:

--- a/cron.go
+++ b/cron.go
@@ -30,9 +30,10 @@ var ErrDuplicateName = errors.New("cron: duplicate entry name")
 // this Cron instance.
 var ErrEntryNotFound = errors.New("cron: entry not found")
 
-// ErrNameRequired is returned by UpsertJob when no WithName option is provided.
-// UpsertJob requires a name to determine whether to create or update.
-var ErrNameRequired = errors.New("cron: UpsertJob requires WithName option")
+// ErrNameRequired is returned by UpsertJob and DrainAndUpsertJob when no
+// WithName option is provided.
+// These methods require a name to address the entry by it.
+var ErrNameRequired = errors.New("cron: WithName option required")
 
 // ErrEntryPaused is returned by TriggerEntry and TriggerEntryByName when
 // attempting to trigger a paused entry. Resume the entry first.
@@ -1901,6 +1902,97 @@ func (c *Cron) upsertScheduled(name string, schedule Schedule, cmd Job, opts []J
 
 	// Entry doesn't exist — create it
 	return c.ScheduleJob(schedule, cmd, opts...)
+}
+
+// DrainAndUpsertJob is the windowless variant of UpsertJob. For an existing
+// named entry it pauses the entry, waits for any in-flight invocation to
+// finish, replaces the schedule and job, then restores the entry's prior
+// paused state. Pausing before the drain guarantees the old schedule cannot
+// fire again between the wait and the replacement — closing the stale-fire
+// window that exists with the two-step WaitForJobByName + UpsertJob sequence:
+//
+//	// Two-step: a tick can still fire the OLD schedule between these calls.
+//	c.WaitForJobByName(name)
+//	c.UpsertJob(spec, job, cron.WithName(name))
+//
+//	// Windowless: no invocation can start under the stale schedule.
+//	c.DrainAndUpsertJob(spec, job, cron.WithName(name))
+//
+// If no entry with the given name exists, the job is created via ScheduleJob;
+// with no stale schedule there is no window to close.
+//
+// The call blocks for as long as the in-flight invocation runs. It does not
+// hold any cron lock while draining, so it never blocks the run loop or other
+// mutators. It is NOT atomic against other concurrent mutators of the same
+// entry (Remove, Resume, Trigger): those are handled gracefully but fall
+// outside the no-stale-fire guarantee.
+//
+// Returns:
+//   - ErrNameRequired if no WithName option is provided
+//   - ErrNilJob if cmd is nil and a matching entry exists (use UpdateSchedule
+//     to change only the schedule)
+//   - Parse errors if spec is invalid for the configured parser
+//   - ErrMaxEntriesReached if creating a new entry would exceed the limit
+func (c *Cron) DrainAndUpsertJob(spec string, cmd Job, opts ...JobOption) (EntryID, error) {
+	name := extractName(opts)
+	if name == "" {
+		return 0, ErrNameRequired
+	}
+
+	schedule, err := c.parser.Parse(spec)
+	if err != nil {
+		return 0, err
+	}
+
+	// Resolve the existing entry once: capture its ID — the swap targets the ID
+	// rather than the name, so a name reused by another entry cannot cause an
+	// ABA — and its prior paused state, so the restore respects caller intent.
+	e := c.EntryByName(name)
+	if !e.Valid() {
+		// No existing entry => no stale schedule => no window. Just create.
+		return c.ScheduleJob(schedule, cmd, opts...)
+	}
+	// Fail fast: with an existing entry, a nil job would only fail at the swap
+	// (UpdateEntry => ErrNilJob) — after needlessly pausing and draining it.
+	if cmd == nil {
+		return 0, ErrNilJob
+	}
+	id := e.ID
+	wasPaused := e.Paused
+
+	// (1) Pause atomically with respect to the run loop. Once this returns,
+	// every subsequent run-loop iteration observes Paused and launches no
+	// further invocation under the stale schedule. PauseEntry's only failure
+	// mode is ErrEntryNotFound (the entry was removed concurrently) — there is
+	// then no stale schedule to replace, so create instead.
+	if c.PauseEntry(id) != nil {
+		return c.ScheduleJob(schedule, cmd, opts...)
+	}
+
+	// (2) Drain the invocation that may already be in flight. The only one
+	// possible is a fire the run loop launched in the same iteration just
+	// before it read the pause request; its tracker was incremented
+	// synchronously before the job goroutine started, so this wait observes and
+	// joins it. The run loop never blocks on this wait, so there is no deadlock.
+	// Wait by ID (not name) so we drain the exact entry we paused and will swap,
+	// even if the name is concurrently reused by a different entry.
+	c.WaitForJob(id)
+
+	// (3) Replace schedule and job while still paused — UpdateEntry leaves
+	// Paused untouched, so no fire can occur during the swap. With a non-nil
+	// cmd its only failure mode is ErrEntryNotFound (removed during the drain);
+	// create instead, matching the pause path.
+	if c.UpdateEntry(id, schedule, cmd) != nil {
+		return c.ScheduleJob(schedule, cmd, opts...)
+	}
+
+	// (4) Restore prior paused state: resume only if the caller had not already
+	// paused the entry themselves. ResumeEntry only fails with ErrEntryNotFound
+	// (removed after the swap), in which case there is nothing to resume.
+	if !wasPaused {
+		_ = c.ResumeEntry(id)
+	}
+	return id, nil
 }
 
 // now returns current time in c location.

--- a/cron_test.go
+++ b/cron_test.go
@@ -5536,3 +5536,384 @@ func TestDSTFallBack_ScheduleExhaustedAfterSkip(t *testing.T) {
 		t.Errorf("expected zero Next after schedule exhaustion, got %v", entries[0].Next)
 	}
 }
+
+// --- DrainAndUpsertJob tests ---
+
+// waitForPaused blocks until the named entry reports paused, or fails the test
+// after a timeout. Used to synchronize with DrainAndUpsertJob's internal pause
+// step without exposing it.
+func waitForPaused(t *testing.T, c *Cron, name string) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for {
+		if c.IsEntryPausedByName(name) {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("entry %q never became paused", name)
+		case <-time.After(time.Millisecond):
+		}
+	}
+}
+
+// TestDrainAndUpsertNoStaleFire is the core guarantee: while DrainAndUpsertJob
+// is blocked draining an in-flight invocation, the old schedule must NOT fire
+// again even though the clock advances well past its next tick. The job is a
+// bare FuncJob (no SkipIfStillRunning) so any extra launch would be observable
+// as a second increment.
+func TestDrainAndUpsertNoStaleFire(t *testing.T) {
+	start := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	clock := NewFakeClock(start)
+	c := New(WithClock(clock), WithParser(secondParser))
+	c.Start()
+	defer c.Stop()
+
+	var oldRuns, newRuns int32
+	jobStarted := make(chan struct{})
+	jobRelease := make(chan struct{})
+	var startOnce sync.Once
+
+	origID, err := c.AddFunc("* * * * * *", func() {
+		atomic.AddInt32(&oldRuns, 1)
+		startOnce.Do(func() { close(jobStarted) })
+		<-jobRelease
+	}, WithName("ttl"))
+	if err != nil {
+		t.Fatalf("AddFunc failed: %v", err)
+	}
+
+	// Fire the old job exactly once and wait until it is provably in flight.
+	clock.BlockUntil(1)
+	clock.Advance(time.Second)
+	select {
+	case <-jobStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("old job did not start")
+	}
+
+	// Replace the job from another goroutine; it will pause the entry, then
+	// block in the drain because the old invocation is still held.
+	upsertDone := make(chan struct{})
+	var gotID EntryID
+	var upsertErr error
+	go func() {
+		gotID, upsertErr = c.DrainAndUpsertJob("* * * * * *", FuncJob(func() {
+			atomic.AddInt32(&newRuns, 1)
+		}), WithName("ttl"))
+		close(upsertDone)
+	}()
+
+	// Once the entry is paused, advance the clock far past several old ticks.
+	waitForPaused(t, c, "ttl")
+	clock.Advance(5 * time.Second)
+	time.Sleep(20 * time.Millisecond)
+
+	// The old schedule must not have fired again, and the upsert must still be
+	// blocked in the drain.
+	if n := atomic.LoadInt32(&oldRuns); n != 1 {
+		t.Fatalf("stale fire: expected oldRuns==1 while draining, got %d", n)
+	}
+	select {
+	case <-upsertDone:
+		t.Fatal("DrainAndUpsertJob returned before the in-flight job was released")
+	default:
+	}
+
+	// Release the in-flight job; the drain completes, the swap + resume run.
+	close(jobRelease)
+	select {
+	case <-upsertDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("DrainAndUpsertJob did not return after release")
+	}
+	if upsertErr != nil {
+		t.Fatalf("DrainAndUpsertJob error: %v", upsertErr)
+	}
+	if gotID != origID {
+		t.Errorf("expected preserved entry ID %v, got %v", origID, gotID)
+	}
+
+	// The new job runs on the next tick; the old one never fires again.
+	clock.BlockUntil(1)
+	clock.Advance(time.Second)
+	deadline := time.After(2 * time.Second)
+	for atomic.LoadInt32(&newRuns) == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("replacement job did not run")
+		case <-time.After(time.Millisecond):
+		}
+	}
+	if n := atomic.LoadInt32(&oldRuns); n != 1 {
+		t.Errorf("old job fired after replacement: oldRuns=%d", n)
+	}
+}
+
+// TestDrainAndUpsertDrainsInFlight verifies the call blocks until the in-flight
+// invocation completes (not merely until the entry is paused).
+func TestDrainAndUpsertDrainsInFlight(t *testing.T) {
+	c := New()
+	c.Start()
+	defer c.Stop()
+
+	jobStarted := make(chan struct{})
+	jobRelease := make(chan struct{})
+	var startOnce sync.Once
+	_, err := c.AddFunc("@every 1s", func() {
+		startOnce.Do(func() { close(jobStarted) })
+		<-jobRelease
+	}, WithName("drainme"), WithRunImmediately())
+	if err != nil {
+		t.Fatalf("AddFunc failed: %v", err)
+	}
+
+	select {
+	case <-jobStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("job did not start")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		c.DrainAndUpsertJob("@every 1s", FuncJob(func() {}), WithName("drainme"))
+		close(done)
+	}()
+
+	// Must still be draining while the job is held.
+	select {
+	case <-done:
+		t.Fatal("DrainAndUpsertJob returned before in-flight job completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(jobRelease)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("DrainAndUpsertJob did not return after release")
+	}
+}
+
+// TestDrainAndUpsertCreatesWhenAbsent verifies the create path: no existing
+// entry means no window, and a new entry is scheduled un-paused.
+func TestDrainAndUpsertCreatesWhenAbsent(t *testing.T) {
+	start := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	clock := NewFakeClock(start)
+	c := New(WithClock(clock), WithParser(secondParser))
+	c.Start()
+	defer c.Stop()
+
+	var runs int32
+	id, err := c.DrainAndUpsertJob("* * * * * *", FuncJob(func() {
+		atomic.AddInt32(&runs, 1)
+	}), WithName("fresh"))
+	if err != nil {
+		t.Fatalf("DrainAndUpsertJob failed: %v", err)
+	}
+	if !c.EntryByName("fresh").Valid() {
+		t.Fatal("entry not created")
+	}
+	if c.IsEntryPausedByName("fresh") {
+		t.Error("newly created entry should not be paused")
+	}
+	if !c.Entry(id).Valid() {
+		t.Fatalf("returned id %v is not a valid entry", id)
+	}
+
+	clock.BlockUntil(1)
+	clock.Advance(time.Second)
+	deadline := time.After(2 * time.Second)
+	for atomic.LoadInt32(&runs) == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("created job did not run")
+		case <-time.After(time.Millisecond):
+		}
+	}
+}
+
+// TestDrainAndUpsertPreservesEntryID verifies an update reuses the same ID.
+func TestDrainAndUpsertPreservesEntryID(t *testing.T) {
+	c := New()
+
+	id1, err := c.DrainAndUpsertJob("@every 1h", FuncJob(func() {}), WithName("keep-id"))
+	if err != nil {
+		t.Fatalf("first DrainAndUpsertJob failed: %v", err)
+	}
+	id2, err := c.DrainAndUpsertJob("@every 2h", FuncJob(func() {}), WithName("keep-id"))
+	if err != nil {
+		t.Fatalf("second DrainAndUpsertJob failed: %v", err)
+	}
+	if id1 != id2 {
+		t.Errorf("DrainAndUpsertJob should preserve EntryID: %v != %v", id1, id2)
+	}
+	if got := len(c.Entries()); got != 1 {
+		t.Errorf("expected 1 entry, got %d", got)
+	}
+}
+
+// TestDrainAndUpsertRestoresUnpaused verifies that an entry which was running
+// (not paused) is left un-paused after replacement.
+func TestDrainAndUpsertRestoresUnpaused(t *testing.T) {
+	c := New()
+
+	if _, err := c.AddFunc("@every 1h", func() {}, WithName("u")); err != nil {
+		t.Fatalf("AddFunc failed: %v", err)
+	}
+	if _, err := c.DrainAndUpsertJob("@every 2h", FuncJob(func() {}), WithName("u")); err != nil {
+		t.Fatalf("DrainAndUpsertJob failed: %v", err)
+	}
+	if c.IsEntryPausedByName("u") {
+		t.Error("entry should be un-paused after replacement")
+	}
+}
+
+// TestDrainAndUpsertLeavesAlreadyPausedPaused verifies that an entry the caller
+// had paused before the call remains paused afterward.
+func TestDrainAndUpsertLeavesAlreadyPausedPaused(t *testing.T) {
+	c := New()
+
+	if _, err := c.AddFunc("@every 1h", func() {}, WithName("p")); err != nil {
+		t.Fatalf("AddFunc failed: %v", err)
+	}
+	if err := c.PauseEntryByName("p"); err != nil {
+		t.Fatalf("PauseEntryByName failed: %v", err)
+	}
+	if _, err := c.DrainAndUpsertJob("@every 2h", FuncJob(func() {}), WithName("p")); err != nil {
+		t.Fatalf("DrainAndUpsertJob failed: %v", err)
+	}
+	if !c.IsEntryPausedByName("p") {
+		t.Error("entry paused by caller should remain paused after replacement")
+	}
+}
+
+// TestDrainAndUpsertRequiresName verifies ErrNameRequired with no WithName.
+func TestDrainAndUpsertRequiresName(t *testing.T) {
+	c := New()
+	if _, err := c.DrainAndUpsertJob("@every 1h", FuncJob(func() {})); !errors.Is(err, ErrNameRequired) {
+		t.Errorf("expected ErrNameRequired, got %v", err)
+	}
+}
+
+// TestDrainAndUpsertInvalidSpec verifies parse errors surface with no side effect.
+func TestDrainAndUpsertInvalidSpec(t *testing.T) {
+	c := New()
+	if _, err := c.DrainAndUpsertJob("not-a-spec!!!", FuncJob(func() {}), WithName("bad")); err == nil {
+		t.Error("expected parse error for invalid spec")
+	}
+	if c.EntryByName("bad").Valid() {
+		t.Error("no entry should be created on parse error")
+	}
+}
+
+// TestDrainAndUpsertNilJobOnExisting mirrors UpsertJob: a nil job on an existing
+// entry returns ErrNilJob. It fails fast before pausing, so the entry is left
+// un-paused.
+func TestDrainAndUpsertNilJobOnExisting(t *testing.T) {
+	c := New()
+	if _, err := c.AddFunc("@every 1h", func() {}, WithName("niljob")); err != nil {
+		t.Fatalf("AddFunc failed: %v", err)
+	}
+	if _, err := c.DrainAndUpsertJob("@every 2h", nil, WithName("niljob")); !errors.Is(err, ErrNilJob) {
+		t.Errorf("expected ErrNilJob, got %v", err)
+	}
+	if c.IsEntryPausedByName("niljob") {
+		t.Error("entry should be restored un-paused after a failed swap")
+	}
+}
+
+// TestDrainAndUpsertSchedulerStopped verifies the method works before Start():
+// the drain returns immediately (no run loop launches jobs) and the entry is
+// updated in place.
+func TestDrainAndUpsertSchedulerStopped(t *testing.T) {
+	start := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	clock := NewFakeClock(start)
+	c := New(WithClock(clock), WithParser(secondParser))
+
+	id1, err := c.AddFunc("@every 1h", func() {}, WithName("stopped"))
+	if err != nil {
+		t.Fatalf("AddFunc failed: %v", err)
+	}
+	id2, err := c.DrainAndUpsertJob("* * * * * *", FuncJob(func() {}), WithName("stopped"))
+	if err != nil {
+		t.Fatalf("DrainAndUpsertJob failed: %v", err)
+	}
+	if id1 != id2 {
+		t.Errorf("expected preserved ID, got %v != %v", id1, id2)
+	}
+
+	var runs int32
+	// Re-point to a counting job, still stopped, then start and confirm it fires.
+	if _, err := c.DrainAndUpsertJob("* * * * * *", FuncJob(func() {
+		atomic.AddInt32(&runs, 1)
+	}), WithName("stopped")); err != nil {
+		t.Fatalf("second DrainAndUpsertJob failed: %v", err)
+	}
+	c.Start()
+	defer c.Stop()
+	clock.BlockUntil(1)
+	clock.Advance(time.Second)
+	deadline := time.After(2 * time.Second)
+	for atomic.LoadInt32(&runs) == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("job did not fire after Start")
+		case <-time.After(time.Millisecond):
+		}
+	}
+}
+
+// TestDrainAndUpsertRecreatesIfRemovedDuringDrain covers the concurrent-removal
+// path: if the entry is removed while DrainAndUpsertJob is draining the
+// in-flight invocation, the swap finds nothing and the job is re-created.
+func TestDrainAndUpsertRecreatesIfRemovedDuringDrain(t *testing.T) {
+	c := New()
+	c.Start()
+	defer c.Stop()
+
+	jobStarted := make(chan struct{})
+	jobRelease := make(chan struct{})
+	var startOnce, removeOnce sync.Once
+	_, err := c.AddFunc("@every 1s", func() {
+		startOnce.Do(func() { close(jobStarted) })
+		<-jobRelease
+		// Remove our own entry before returning so the drain completes against a
+		// now-absent entry and the swap falls through to create.
+		removeOnce.Do(func() { c.RemoveByName("vanishing") })
+	}, WithName("vanishing"), WithRunImmediately())
+	if err != nil {
+		t.Fatalf("AddFunc failed: %v", err)
+	}
+
+	select {
+	case <-jobStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("job did not start")
+	}
+
+	done := make(chan struct{})
+	var derr error
+	go func() {
+		_, derr = c.DrainAndUpsertJob("@every 2s", FuncJob(func() {}), WithName("vanishing"))
+		close(done)
+	}()
+
+	// Wait until the upsert has paused the entry (so it is past PauseEntry and
+	// into the drain), then release the job — which removes the entry — so the
+	// subsequent UpdateEntry sees ErrEntryNotFound and re-creates.
+	waitForPaused(t, c, "vanishing")
+	close(jobRelease)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("DrainAndUpsertJob did not return")
+	}
+	if derr != nil {
+		t.Fatalf("DrainAndUpsertJob error: %v", derr)
+	}
+	if !c.EntryByName("vanishing").Valid() {
+		t.Fatal("entry should have been re-created after concurrent removal")
+	}
+}

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -365,6 +365,33 @@ if err := c.UpdateEntryJobByName(name, spec, job); errors.Is(err, cron.ErrEntryN
 id, err := c.UpsertJob(spec, job, cron.WithName(name))
 ```
 
+#### func (*Cron) DrainAndUpsertJob
+
+```go
+func (c *Cron) DrainAndUpsertJob(spec string, cmd Job, opts ...JobOption) (EntryID, error)
+```
+
+DrainAndUpsertJob is the windowless variant of `UpsertJob`. For an existing
+named entry it pauses the entry, waits for any in-flight invocation to finish,
+replaces the schedule and job, then restores the entry's prior paused state.
+Pausing before the drain guarantees the old schedule cannot fire again between
+the wait and the replacement — closing the gap present in the two-step
+`WaitForJobByName` + `UpsertJob` sequence. If no entry with the given name
+exists it creates one (no stale schedule ⇒ no window). Same options and errors
+as `UpsertJob`; a `WithName` option is required.
+
+It blocks for as long as the in-flight invocation runs but holds no cron lock
+while draining, so it never blocks the run loop or other mutators. It is not
+atomic against other concurrent mutators of the same entry (`Remove`, `Resume`,
+`Trigger`); those are handled gracefully but fall outside the no-stale-fire
+guarantee. See [ADR-022](adr/ADR-022-drain-and-upsert.md).
+
+**Example:**
+```go
+// Graceful, windowless reschedule in one call:
+id, err := c.DrainAndUpsertJob(newSpec, newJob, cron.WithName("my-job"))
+```
+
 #### func (*Cron) WaitForJob
 
 ```go
@@ -397,6 +424,10 @@ if the entry is not currently running or no entry has the given name.
 cr.WaitForJobByName("my-job")
 cr.UpsertJob(newSpec, newJob, cron.WithName("my-job"))
 ```
+
+> **Note:** the two calls above are not atomic — the old schedule can fire once
+> between them. Use [`DrainAndUpsertJob`](#func-cron-drainandupsertjob) for a
+> windowless reschedule.
 
 #### func (*Cron) IsJobRunning
 

--- a/docs/adr/ADR-022-drain-and-upsert.md
+++ b/docs/adr/ADR-022-drain-and-upsert.md
@@ -1,0 +1,147 @@
+# ADR-022: Windowless Drain-and-Replace (`DrainAndUpsertJob`)
+
+## Status
+Accepted
+
+## Date
+2026-06-02
+
+## Context
+
+The idiomatic way to reschedule a named entry without overlapping the
+in-flight invocation is the two-step sequence:
+
+```go
+cr.WaitForJobByName("my-job")
+cr.UpsertJob(newSpec, newJob, cron.WithName("my-job"))
+```
+
+`WaitForJobByName` drains the running invocation, then `UpsertJob` replaces
+the entry. This was reported (via the [weaviate](https://github.com/weaviate/weaviate)
+object-TTL scheduler) to have a narrow but real correctness gap:
+
+> Previously a `RemoveByName` → wait → `AddJob` sequence guaranteed that no
+> further invocation could start once the wait returned. With
+> `WaitForJobByName` → `UpsertJob` there is a window between the two calls in
+> which the old schedule can still fire one more time.
+
+The gap exists because `WaitForJobByName` does **not** unschedule the entry —
+it only blocks on the per-entry job tracker. Between the wait returning and
+`UpsertJob` installing the new schedule, the run loop is free to fire the
+stale schedule once more (e.g. if the drained invocation ran long enough to
+cross the next tick boundary). `SkipIfStillRunning` prevents a concurrent
+double-run but not this extra invocation under the old schedule.
+
+The old `RemoveByName` → wait → `AddJob` pattern did not have the gap because
+`RemoveByName` unschedules the entry *before* the wait, so no fire is possible
+after the drain. The migration to `UpsertJob` traded that guarantee for the
+ergonomics of atomic create-or-update.
+
+## Decision
+
+Add `DrainAndUpsertJob(spec string, cmd Job, opts ...JobOption) (EntryID, error)`
+— a windowless variant of `UpsertJob` that closes the gap by **pausing the
+entry before draining**:
+
+1. Resolve the entry by name once; capture its `ID` and prior `Paused` state.
+   If absent, create via `ScheduleJob` (no stale schedule ⇒ no window).
+2. `PauseEntry(id)` — atomic with respect to the run loop.
+3. `WaitForJobByName(name)` — drain any in-flight invocation.
+4. `UpdateEntry(id, schedule, cmd)` — swap schedule and job while paused.
+5. `ResumeEntry(id)` — only if the caller had not already paused the entry.
+
+The method **composes existing public methods**; it does not add a new run-loop
+request type or a monolithic locked operation. Each composed call acquires and
+releases `runningMu` independently, so the blocking drain in step 3 never holds
+a cron lock and never stalls the run loop or other mutators.
+
+### Why this is windowless
+
+The guarantee — *no invocation can start under the stale schedule after the
+drain returns and before the swap completes* — rests on three properties of the
+scheduler, all verified in `cron.go`:
+
+1. **Single-goroutine select.** The run loop processes the timer-fire arm and
+   the pause arm as mutually exclusive cases of one `select` on one goroutine.
+   `processDueEntries` runs to completion within an arm before the loop returns
+   to `select`.
+2. **Pause is honored before any later fire.** `PauseEntry` sends synchronously
+   on the pause channel and blocks on the reply. Because the run loop is
+   sequential, every iteration after the reply observes `Paused == true` and
+   takes the skip branch in `processDueEntries`, launching no job.
+3. **Synchronous tracker increment.** The only invocation that can still be in
+   flight when `PauseEntry` returns is one launched by a timer fire processed in
+   the same iteration immediately before the pause request was read. That fire
+   increments the per-entry job tracker **synchronously** (inside
+   `processDueEntries`, before the `go func()` that runs the job), so
+   `WaitForJobByName` provably observes and joins it.
+
+`updateSchedule` does not touch `Paused`, so the entry stays paused across the
+swap; the resume in step 5 re-enables the **new** schedule, whose `Next` was
+computed at swap time.
+
+### Explicit non-guarantee
+
+`DrainAndUpsertJob` is **not** atomic against *other* concurrent mutators of the
+same entry. Between the composed calls another goroutine may `Remove`, `Resume`,
+or `Trigger` the entry. These are handled gracefully — removal surfaces as the
+`ErrEntryNotFound` → create fallthrough; a `Trigger` while paused is rejected
+with `ErrEntryPaused` or fires the already-swapped new job — but they fall
+outside the no-stale-fire guarantee, which is specifically about the **old
+schedule** not firing after the drain. The swap targets the captured `ID`
+(not the name), so a name reused by a different entry between drain and swap
+cannot cause an ABA.
+
+## Consequences
+
+### Positive
+- Closes the stale-fire window for the common graceful-reschedule use case with
+  a single call.
+- No new run-loop machinery, no new struct fields, no lock held across the
+  blocking drain — low risk, easy to reason about.
+- Mirrors `UpsertJob`'s contract exactly (same options, same errors), so it is a
+  drop-in replacement for the two-step pattern.
+
+### Negative
+- Composes four run-loop round trips (lookup, pause, swap, resume) plus the
+  drain, versus `UpsertJob`'s one. The extra round trips are O(1) and dwarfed by
+  the drain wait; not a concern in practice.
+- The windowless guarantee depends on the run loop incrementing the job tracker
+  **synchronously before** launching the job goroutine. A future refactor that
+  moved `start()` into the goroutine would reopen the window. Flagged here and
+  pinned by `TestDrainAndUpsertNoStaleFire`.
+
+### Neutral
+- Purely additive. `UpsertJob` and `WaitForJobByName` are unchanged.
+
+## Alternatives Considered
+
+### 1. Keep the two-step `WaitForJobByName` + `UpsertJob`
+Document the window and rely on idempotent jobs.
+
+**Rejected** as the default answer: the window is subtle, surfaces only under
+load, and "make your job idempotent" is not always available to callers. Keeping
+the two-step API is fine (it stays), but a windowless option should exist.
+
+### 2. A single monolithic run-loop operation
+Add one request type carrying `{pause, drainSignal, swap, restore}` handled
+atomically inside the run loop.
+
+**Rejected:** the drain can block for the full duration of a long-running job.
+Performing it inside the run loop would stall every other entry and mutator for
+that duration — a worse failure mode than the narrow window it closes. The
+composition achieves the required guarantee without blocking the loop.
+
+### 3. Restore the `RemoveByName` → wait → `AddJob` ordering
+Unschedule first, then drain, then re-create.
+
+**Rejected:** it loses the atomic create-or-update and entry-ID stability that
+`UpsertJob` provides, and briefly leaves the entry absent. Pausing achieves the
+same "cannot fire" property while keeping the entry (and its ID) in place.
+
+## References
+
+- weaviate object-TTL scheduler review that motivated this change
+  ([weaviate#10477](https://github.com/weaviate/weaviate/pull/10477))
+- [ADR-017](ADR-017-job-with-context.md): per-entry context (canceled on replacement)
+- `WaitForJobByName`, `UpsertJob`, `PauseEntry`/`ResumeEntry` in `cron.go`


### PR DESCRIPTION
## What

Adds `DrainAndUpsertJob(spec string, cmd Job, opts ...JobOption) (EntryID, error)` — a **windowless** variant of `UpsertJob` for graceful rescheduling of a named entry.

```go
// Two-step today: a tick can still fire the OLD schedule between these calls.
cr.WaitForJobByName("my-job")
cr.UpsertJob(newSpec, newJob, cron.WithName("my-job"))

// New: no invocation can start under the stale schedule.
cr.DrainAndUpsertJob(newSpec, newJob, cron.WithName("my-job"))
```

## Why

The idiomatic `WaitForJobByName` → `UpsertJob` reschedule has a narrow correctness gap: `WaitForJobByName` drains the running invocation but does **not** unschedule the entry, so a cron tick landing between the wait returning and `UpsertJob` installing the new schedule can fire the **old** schedule one more time. The previous `RemoveByName` → wait → `AddJob` pattern didn't have this gap (remove unscheduled first).

Reported on the [weaviate object-TTL scheduler](https://github.com/weaviate/weaviate/pull/10477): the maintainer asked for an atomic "wait + upsert" variant to close the window entirely.

## How

`DrainAndUpsertJob` composes existing serialized methods:

1. resolve the entry by name once (capture `ID` + prior `Paused`); if absent → `ScheduleJob` (no stale schedule ⇒ no window)
2. `PauseEntry(id)` — atomic w.r.t. the run loop; after it returns, no further fire of the stale schedule can start
3. `WaitForJobByName(name)` — drain the in-flight invocation
4. `UpdateEntry(id, schedule, cmd)` — swap schedule + job while still paused (`updateSchedule` leaves `Paused` untouched)
5. `ResumeEntry(id)` — only if the caller hadn't already paused it

The drain holds **no** cron lock, so it never blocks the run loop or other mutators. The swap targets the captured `ID` (not the name), avoiding an ABA if the name is reused.

### Guarantee & non-guarantee

- **Closes the stale-fire window.** Proof rests on three verified scheduler invariants: single-goroutine `select` (timer-fire and pause arms are mutually exclusive), pause honored before any later fire, and synchronous job-tracker increment before the job goroutine launches (so the drain provably joins the last pre-pause fire). Full rationale in `docs/adr/ADR-022`.
- **Not atomic against other mutators.** A concurrent `Remove`/`Resume`/`Trigger` is handled gracefully (e.g. `ErrEntryNotFound` → create) but falls outside the no-stale-fire guarantee. Documented explicitly.

## Tests

10 tests, all green under `-race`. The core proof, `TestDrainAndUpsertNoStaleFire`, holds an in-flight invocation, advances the FakeClock past several old ticks while the drain is blocked, and asserts the old schedule never fires again. Plus: drains-in-flight, create-when-absent, ID preservation, restore-unpaused, leave-already-paused, requires-name, invalid-spec, nil-job, scheduler-stopped.

## Docs

ADR-022, API reference entry + a cross-reference note on `WaitForJobByName`, README graceful-replacement section, CHANGELOG.

## Notes for review

- Method name `DrainAndUpsertJob` mirrors `StopAndWait`/`UpsertJob` conventions; open to `UpsertJobWaiting` / `ReplaceJobGracefully` if preferred.
- The local pre-push `lint-full` hook flagged 6 `goconst` + 6 `staticcheck` issues that are **pre-existing** in `parser.go`/`validate.go`/`workflow_test.go` (not touched here) — surfaced by a newer local golangci-lint (v2.12.2) than the CI-pinned one. Left untouched to keep this PR surgical; happy to file a separate cleanup.