### PR TITLE
chore: release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Originally based on [robfig/cron](https://github.com/robfig/cron).
 
 ## [Unreleased]
 
+### Planned for v2
+- Context-aware Job interface with graceful shutdown support
+
+## [0.15.0] - 2026-06-02
+
 ### Added
 - **`DrainAndUpsertJob`** ([PR#381]): windowless variant of `UpsertJob` for graceful
   reschedule. Pauses the named entry, drains any in-flight invocation, swaps the
@@ -19,9 +24,6 @@ Originally based on [robfig/cron](https://github.com/robfig/cron).
   cron lock. Motivated by the
   [weaviate object-TTL scheduler](https://github.com/weaviate/weaviate/pull/10477);
   see [ADR-022](docs/adr/ADR-022-drain-and-upsert.md).
-
-### Planned for v2
-- Context-aware Job interface with graceful shutdown support
 
 ## [0.14.0] - 2026-04-16
 
@@ -576,7 +578,10 @@ This fork includes all features from robfig/cron v3 plus:
    _, err := cron.ParseStandard("*/60 * * * *") // Error: step (60) must be less than range size (60)
    ```
 
-[Unreleased]: https://github.com/netresearch/go-cron/compare/v0.14.0...HEAD
+[Unreleased]: https://github.com/netresearch/go-cron/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/netresearch/go-cron/compare/v0.14.0...v0.15.0
+[0.14.0]: https://github.com/netresearch/go-cron/compare/v0.13.4...v0.14.0
+[0.13.4]: https://github.com/netresearch/go-cron/compare/v0.13.1...v0.13.4
 [0.13.1]: https://github.com/netresearch/go-cron/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/netresearch/go-cron/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/netresearch/go-cron/compare/v0.11.0...v0.12.0


### PR DESCRIPTION
Release prep for **v0.15.0**.

Moves the `DrainAndUpsertJob` entry from `[Unreleased]` into a dated `[0.15.0]` section and updates the compare links. No code changes.

### Highlights
- **`DrainAndUpsertJob`** ([#381](https://github.com/netresearch/go-cron/pull/381)): windowless variant of `UpsertJob` for graceful reschedule — pauses → drains → swaps → restores prior paused state, closing the stale-fire window of the two-step `WaitForJobByName` → `UpsertJob` sequence. See [ADR-022](docs/adr/ADR-022-drain-and-upsert.md).

After merge: tag `main` as `v0.15.0` (signed) to trigger the release workflow.