### PR TITLE
ci: grant id-token and attestations to release workflow caller

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,3 +12,5 @@ jobs:
     uses: netresearch/.github/.github/workflows/golib-create-release.yml@main
     permissions:
       contents: write
+      id-token: write
+      attestations: write


### PR DESCRIPTION
## Problem

The `v0.15.0` tag push triggered the Release workflow, which **failed at startup** ("workflow file issue"). v0.15.0 is the first release since #362 migrated `release.yml` to the `golib-create-release` reusable workflow, so this latent bug was never exercised before.

## Cause

The caller's `create` job grants only `contents: write`, but the reusable workflow's `release` job requests:

```yaml
permissions:
  contents: write
  id-token: write       # cosign keyless signing
  attestations: write   # GitHub artifact attestation
```

A called reusable workflow cannot request **more** permissions than the calling job grants → GitHub rejects the run at startup.

## Fix

Grant the caller `id-token: write` and `attestations: write` in addition to `contents: write`.

After merge, the `v0.15.0` tag will be re-pointed to include this fix so the release can publish (no GitHub release was created by the failed run).