### PR TITLE
ci(codeql): add merge_group trigger to match template

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
   schedule:
     - cron: '30 4 * * 1'
 


### PR DESCRIPTION
Resolves the template drift reported in netresearch/.github#180.

The `go-lib` template added a `merge_group:` trigger to `.github/workflows/codeql.yml` so CodeQL also runs in the merge queue. This repo had drifted; this PR re-syncs the single missing line.

```diff
   pull_request:
     branches: [main]
+  merge_group:
   schedule:
     - cron: '30 4 * * 1'
```