### PR TITLE
doc: enhance documents, explaining that Sunday can be represented by both 0 and 7.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,9 @@ Standard 5-field cron format (minute-first):
 | Hours | Yes | 0-23 | `* / , -` |
 | Day of month | Yes | 1-31 | `* / , - ?` |
 | Month | Yes | 1-12 or JAN-DEC | `* / , -` |
-| Day of week | Yes | 0-6 or SUN-SAT | `* / , - ?` |
+| Day of week | Yes | 0-7 or SUN-SAT | `* / , - ?` |
+
+Note: Sunday can be represented by both 0 and 7.
 
 ### Predefined Schedules
 

--- a/doc.go
+++ b/doc.go
@@ -51,10 +51,12 @@ A cron expression represents a set of times, using 5 space-separated fields.
 	Hours        | Yes        | 0-23            | * / , -
 	Day of month | Yes        | 1-31            | * / , - ?
 	Month        | Yes        | 1-12 or JAN-DEC | * / , -
-	Day of week  | Yes        | 0-6 or SUN-SAT  | * / , - ?
+	Day of week  | Yes        | 0-7 or SUN-SAT  | * / , - ?
 
 Month and Day-of-week field values are case insensitive.  "SUN", "Sun", and
 "sun" are equally accepted.
+
+Note: Sunday can be represented by both 0 and 7.
 
 The specific interpretation of the format is based on the Cron Wikipedia page:
 https://en.wikipedia.org/wiki/Cron

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -151,7 +151,7 @@ Second/Minute: bits 0-59 represent each second/minute
 Hour:          bits 0-23 represent each hour
 Dom:           bits 1-31 represent each day (bit 0 unused)
 Month:         bits 1-12 represent each month
-Dow:           bits 0-6 represent each day of week
+Dow:           bits 0-7 represent each day of week (bit 7 is Sunday-as-7 alias, normalized to bit 0)
 ```
 
 **Next() Algorithm:**

--- a/docs/PROJECT_INDEX.md
+++ b/docs/PROJECT_INDEX.md
@@ -304,7 +304,7 @@ func (f *FakeClock) TimerCount() int          // Active timer count
 │ ┌───────────── hour (0-23)
 │ │ ┌───────────── day of month (1-31)
 │ │ │ ┌───────────── month (1-12 or JAN-DEC)
-│ │ │ │ ┌───────────── day of week (0-6 or SUN-SAT)
+│ │ │ │ ┌───────────── day of week (0-7 or SUN-SAT)
 │ │ │ │ │
 * * * * *
 ```
@@ -316,7 +316,7 @@ func (f *FakeClock) TimerCount() int          // Active timer count
 │ │ ┌───────────── hour (0-23)
 │ │ │ ┌───────────── day of month (1-31)
 │ │ │ │ ┌───────────── month (1-12)
-│ │ │ │ │ ┌───────────── day of week (0-6)
+│ │ │ │ │ ┌───────────── day of week (0-7)
 │ │ │ │ │ │
 * * * * * *
 ```


### PR DESCRIPTION
## Description

Pull request #243 enables the support of using 7 as Sunday. But the documents have not been updated accordingly.
This pull request updates documents, explaining that Sunday can be represented by both 0 and 7.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #389

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have run `make verify` and all checks pass
- [ ] I have added tests covering my changes
- [x] I have updated documentation as needed
- [x] My commits follow conventional commit format

## Testing

No test required, since only documents were changed..

## Additional Notes

N/A