### PR TITLE
chore(docs): drop the sunset Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![CodeQL](https://img.shields.io/github/actions/workflow/status/netresearch/go-cron/codeql.yml?label=CodeQL)](https://github.com/netresearch/go-cron/security/code-scanning)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/netresearch/go-cron/badge)](https://scorecard.dev/viewer/?uri=github.com/netresearch/go-cron)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11696/badge)](https://www.bestpractices.dev/projects/11696)
-[![Go Report Card](https://goreportcard.com/badge/github.com/netresearch/go-cron)](https://goreportcard.com/report/github.com/netresearch/go-cron)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/netresearch/go-cron)](go.mod)
 [![Latest Release](https://img.shields.io/github/v/release/netresearch/go-cron)](https://github.com/netresearch/go-cron/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
Go Report Card has been sunset — goreportcard.com now serves a farewell page:

> After more than a decade of serving the ecosystem, Go Report Card has been sunset.

The badge therefore renders against a dead service and its link leads nowhere useful. Removing it.

Only the badge lines are touched; no other README content changes. Linting coverage is unaffected — `golangci-lint` runs in CI and is what the badge was a proxy for anyway.
