### PR TITLE
feat: add optional job priority

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -385,10 +385,13 @@ type Entry struct {
 	// Visible in Entry snapshots.
 	Triggered bool
 
-	// Priority is the optional priority of the submitted Job. It is used as a
-	// tiebreaker when multiple jobs are scheduled for the same time; higher is better.
-	// Note: the dispatch order of jobs scheduled for the same time with the same
-	// priority is undefined
+	// Priority is the optional priority of the submitted Job. It breaks ties
+	// when multiple entries are due at the same time: the run loop starts
+	// higher-priority job goroutines first. Higher is better; the default is 0.
+	// The guarantee covers goroutine start order only — execution and completion
+	// order is decided by the Go scheduler, and chain wrappers such as Jitter or
+	// SkipIfStillRunning decouple it further. The dispatch order of entries due
+	// at the same time with the same priority is undefined.
 	Priority int
 
 	// entryCtx is a per-entry context derived from the Cron's baseCtx.
@@ -723,9 +726,17 @@ func WithPaused() JobOption {
 	}
 }
 
-// WithPriority sets the Priority of the entry so that if multiple jobs
-// are scheduled for the same second, critical jobs are guaranteed to be dispatched first.
-// Higher is better.
+// WithPriority sets the Priority of the entry. Priority breaks ties when
+// several entries are due at the same time: the run loop starts
+// higher-priority jobs first. Higher is better; the default is 0.
+//
+// The guarantee is limited to the order in which job goroutines are started.
+// Actual execution and completion order is decided by the Go scheduler, and
+// chain wrappers such as Jitter or SkipIfStillRunning decouple it further.
+//
+// Priority is applied at add time. UpdateEntry and UpdateSchedule preserve it;
+// UpsertJob's update path ignores JobOptions, which is the existing behavior
+// for every option.
 //
 // Example:
 //

--- a/cron.go
+++ b/cron.go
@@ -385,6 +385,12 @@ type Entry struct {
 	// Visible in Entry snapshots.
 	Triggered bool
 
+	// Priority is the optional priority of the submitted Job. It is used as a
+	// tiebreaker when multiple jobs are scheduled for the same time; higher is better.
+	// Note: the dispatch order of jobs scheduled for the same time with the same
+	// priority is undefined
+	Priority int
+
 	// entryCtx is a per-entry context derived from the Cron's baseCtx.
 	// It is canceled when the entry is removed or when its job is replaced
 	// via UpdateEntry. Jobs implementing JobWithContext receive this context,
@@ -714,6 +720,22 @@ func WithMissedGracePeriod(d time.Duration) JobOption {
 func WithPaused() JobOption {
 	return func(e *Entry) {
 		e.Paused = true
+	}
+}
+
+// WithPriority sets the Priority of the entry so that if multiple jobs
+// are scheduled for the same second, critical jobs are guaranteed to be dispatched first.
+// Higher is better.
+//
+// Example:
+//
+//	id1, _ := c.AddFunc("0 * * * *", criticalJob, cron.WithPriority(100))
+//	id2, _ := c.AddFunc("0 * * * *", normalJob, cron.WithPriority(50))
+//	id3, _ := c.AddFunc("0 * * * *", lowPriorityJob, cron.WithPriority(25))
+//	id4, _ := c.AddFunc("0 * * * *", defaultJob) // Default priority: 0.
+func WithPriority(p int) JobOption {
+	return func(e *Entry) {
+		e.Priority = p
 	}
 }
 
@@ -2096,6 +2118,7 @@ func (c *Cron) entrySnapshot() []Entry {
 // sortEntriesByTime sorts entries in place by their Next scheduled execution time.
 // Entries with zero time (not scheduled or schedule exhausted) are moved to the
 // end of the slice to keep active entries at the front for efficient iteration.
+// Entries scheduled for the same time are sorted by their Priority.
 func sortEntriesByTime(entries []Entry) {
 	sort.Slice(entries, func(i, j int) bool {
 		// Zero times sort to the end (highest priority = earliest time)
@@ -2104,6 +2127,10 @@ func sortEntriesByTime(entries []Entry) {
 		}
 		if entries[j].Next.IsZero() {
 			return true
+		}
+		if entries[i].Next.Equal(entries[j].Next) {
+			// Higher priority entries sort first
+			return entries[i].Priority > entries[j].Priority
 		}
 		return entries[i].Next.Before(entries[j].Next)
 	})

--- a/cron_test.go
+++ b/cron_test.go
@@ -5061,6 +5061,28 @@ func TestWithPausedOption(t *testing.T) {
 	}
 }
 
+// TestWithPriorityOption verifies that WithPriority sets Entry.Priority
+// through the public API and that entries without the option default to 0.
+func TestWithPriorityOption(t *testing.T) {
+	c := New()
+
+	high, err := c.AddFunc("0 * * * *", func() {}, WithPriority(100))
+	if err != nil {
+		t.Fatalf("AddFunc with WithPriority: %v", err)
+	}
+	deflt, err := c.AddFunc("0 * * * *", func() {})
+	if err != nil {
+		t.Fatalf("AddFunc without priority: %v", err)
+	}
+
+	if got := c.Entry(high).Priority; got != 100 {
+		t.Errorf("expected Priority 100, got %d", got)
+	}
+	if got := c.Entry(deflt).Priority; got != 0 {
+		t.Errorf("expected default Priority 0, got %d", got)
+	}
+}
+
 // TestPauseDoesNotAffectRunningJob verifies that pausing while a job is
 // in-flight does not cancel the currently executing job.
 func TestPauseDoesNotAffectRunningJob(t *testing.T) {

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -979,7 +979,7 @@ type Entry struct {
     MissedGracePeriod time.Duration // Maximum age for catch-up runs
     Paused            bool          // Whether this entry is paused
     Triggered         bool          // Whether this entry uses a triggered schedule
-    Priority          int           // Optional tiebreaker for same second dispatching (higher better)
+    Priority          int           // Optional tiebreaker for entries due at the same time (higher starts first)
 }
 ```
 
@@ -1371,9 +1371,17 @@ c := cron.New(cron.WithWorkflowRetention(50))
 func WithPriority(p int) JobOption
 ```
 
-WithPriority sets the Priority of the entry so that if multiple jobs
-are scheduled for the same second, critical jobs are guaranteed to be dispatched
-first. Default is 0. Higher is better.
+WithPriority sets the Priority of the entry. Priority breaks ties when several
+entries are due at the same time: the run loop starts higher-priority jobs
+first. Higher is better; the default is 0.
+
+The guarantee is limited to the order in which job goroutines are started.
+Actual execution and completion order is decided by the Go scheduler, and chain
+wrappers such as `Jitter` or `SkipIfStillRunning` decouple it further.
+
+Priority is applied at add time. `UpdateEntry` and `UpdateSchedule` preserve
+it; `UpsertJob`'s update path ignores `JobOption`s, which is the existing
+behavior for every option.
 
 **Example:**
 ```go

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -979,6 +979,7 @@ type Entry struct {
     MissedGracePeriod time.Duration // Maximum age for catch-up runs
     Paused            bool          // Whether this entry is paused
     Triggered         bool          // Whether this entry uses a triggered schedule
+    Priority          int           // Optional tiebreaker for same second dispatching (higher better)
 }
 ```
 
@@ -1362,6 +1363,24 @@ retention (not recommended for long-running services).
 **Example:**
 ```go
 c := cron.New(cron.WithWorkflowRetention(50))
+```
+
+#### func WithPriority
+
+```go
+func WithPriority(p int) JobOption
+```
+
+WithPriority sets the Priority of the entry so that if multiple jobs
+are scheduled for the same second, critical jobs are guaranteed to be dispatched
+first. Default is 0. Higher is better.
+
+**Example:**
+```go
+id1, _ := c.AddFunc("0 * * * *", criticalJob, cron.WithPriority(100))
+id2, _ := c.AddFunc("0 * * * *", normalJob, cron.WithPriority(50))
+id3, _ := c.AddFunc("0 * * * *", lowPriorityJob, cron.WithPriority(25))
+id4, _ := c.AddFunc("0 * * * *", defaultJob) // Default priority: 0.
 ```
 
 ---

--- a/example_test.go
+++ b/example_test.go
@@ -1374,3 +1374,19 @@ func ExampleDomW_lastWeekday() {
 	// 31W from Feb 1: March 29
 	// LW from Feb 1: February 29
 }
+
+// This example demonstrates priority as a tiebreaker for entries due at the
+// same time. Higher-priority job goroutines are started first; execution and
+// completion order remains up to the Go scheduler.
+func ExampleWithPriority() {
+	c := cron.New()
+
+	id1, _ := c.AddFunc("0 * * * *", func() {}, cron.WithPriority(100))
+	id2, _ := c.AddFunc("0 * * * *", func() {}) // Default priority: 0.
+
+	fmt.Println(c.Entry(id1).Priority)
+	fmt.Println(c.Entry(id2).Priority)
+	// Output:
+	// 100
+	// 0
+}

--- a/heap.go
+++ b/heap.go
@@ -24,6 +24,10 @@ func (h entryHeap) Less(i, j int) bool {
 	if h[j].Next.IsZero() {
 		return true
 	}
+	if h[i].Next.Equal(h[j].Next) {
+		// Higher priority entries sort first
+		return h[i].Priority > h[j].Priority
+	}
 	return h[i].Next.Before(h[j].Next)
 }
 

--- a/heap_test.go
+++ b/heap_test.go
@@ -568,3 +568,37 @@ func BenchmarkRemoveAtWithIndex(b *testing.B) {
 		index[e.ID] = e
 	}
 }
+
+// TestScheduleTieSortsByPriority tests that entries scheduled for
+// the same second are sorted by priority
+func TestScheduleTieSortsByPriority(t *testing.T) {
+	h := &entryHeap{}
+	heap.Init(h)
+
+	// Add entries with different times
+	now := time.Now()
+	entries := []*Entry{
+		{ID: 1, Next: now, heapIndex: -1, Priority: 25},
+		{ID: 2, Next: now, heapIndex: -1, Priority: 50},
+		{ID: 3, Next: now, heapIndex: -1, Priority: 100},
+		{ID: 4, Next: now, heapIndex: -1},
+	}
+
+	for _, e := range entries {
+		heap.Push(h, e)
+	}
+
+	// Peek should return highest priority entry (ID=3)
+	if h.Peek().ID != 3 {
+		t.Errorf("expected ID 3 at top, got %d", h.Peek().ID)
+	}
+
+	// Pop should return in order: 3,2,1,4
+	expectedOrder := []EntryID{3, 2, 1, 4}
+	for _, expectedID := range expectedOrder {
+		e := heap.Pop(h).(*Entry)
+		if e.ID != expectedID {
+			t.Errorf("expected ID %d, got %d", expectedID, e.ID)
+		}
+	}
+}

--- a/heap_test.go
+++ b/heap_test.go
@@ -570,12 +570,13 @@ func BenchmarkRemoveAtWithIndex(b *testing.B) {
 }
 
 // TestScheduleTieSortsByPriority tests that entries scheduled for
-// the same second are sorted by priority
+// the same time are sorted by priority
 func TestScheduleTieSortsByPriority(t *testing.T) {
 	h := &entryHeap{}
 	heap.Init(h)
 
-	// Add entries with different times
+	// All entries share the same Next time — the tie is the point of the
+	// test: with equal times, the heap must order by Priority alone.
 	now := time.Now()
 	entries := []*Entry{
 		{ID: 1, Next: now, heapIndex: -1, Priority: 25},


### PR DESCRIPTION
Adds an optional priority to entries as a tiebreaker when several entries are due at the same time: the run loop starts higher-priority job goroutines first. Execution and completion order remains with the Go scheduler.

## Description

Currently when two or more jobs are scheduled to run at the same second the order of dispatch is unknown. This changes allow for an optional priority parameter to break the tie.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [X] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #301

## Checklist

- [X] My code follows the project's coding standards
- [X] I have run `make verify` and all checks pass
- [X] I have added tests covering my changes
- [X] I have updated documentation as needed
- [X] My commits follow conventional commit format

## Testing

Added a heap-level test asserting that entries due at the same time pop in priority order, a public-API test asserting `Entry.Priority` via `AddFunc` + `WithPriority` (and the default 0), and an `ExampleWithPriority`.

## Additional Notes

Let me know if there's anything to modify in the PR.
