### PR TITLE
chore: point CODEOWNERS at existing org teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,18 +1,9 @@
-# CODEOWNERS for netresearch/go-cron
-#
-# This file defines the default reviewers for pull requests.
-# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# CODEOWNERS - Defines code ownership for pull request reviews
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# Default owners for everything in the repository
-* @netresearch/go-cron-maintainers
+# Default owners for everything in the repo
+* @CybotTM @netresearch/netresearch
 
-# Core scheduling logic requires careful review
-cron.go @netresearch/go-cron-maintainers
-parser.go @netresearch/go-cron-maintainers
-spec.go @netresearch/go-cron-maintainers
-
-# CI/CD changes need maintainer approval
-.github/ @netresearch/go-cron-maintainers
-
-# Security-sensitive files
-.golangci.yml @netresearch/go-cron-maintainers
+# Security-sensitive files require security team review
+/.github/workflows/ @CybotTM @netresearch/sec
+/SECURITY.md @CybotTM @netresearch/sec


### PR DESCRIPTION
Aligns CODEOWNERS with the estate standard (ofelia's pattern, copied verbatim): default owners `@CybotTM` + `@netresearch/netresearch` (11 members), workflows and SECURITY.md additionally `@netresearch/sec` (6 members). Code-owner review is not an enforced merge gate on this repo — this is reviewer auto-request routing.

The previous file assigned everything to `@netresearch/go-cron-maintainers`, a team that does not exist in the org, so no review was ever auto-requested. No per-repo maintainer team exists anywhere in the estate; the org-wide teams are the measured pattern.

Fixes #400