### PR TITLE
feat: Go 1.27 toolchain, minimum Go 1.26, go fix modernization

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -12,20 +12,17 @@ The following protection rules should be configured in GitHub Settings > Branche
 - [x] Require status checks to pass before merging
 - [x] Require branches to be up to date before merging
 
-**Required checks:**
-- `unit / unit tests (1.25.x, ubuntu-latest)`
-- `unit / unit tests (1.25.x, windows-latest)`
-- `unit / unit tests (1.25.x, macos-latest)`
-- `unit / unit tests (1.26.x, ubuntu-latest)`
-- `unit / unit tests (1.26.x, windows-latest)`
-- `unit / unit tests (1.26.x, macos-latest)`
-- `lint / golangci-lint`
-- `vulncheck / govulncheck`
-- `gosec / gosec`
-- `trivy / trivy scan (fs)`
-- `workflow-lint / actionlint`
-- `integration / integration tests`
-- `license-check / license compliance`
+**Required checks** (as configured in the live `main` ruleset; CI runs the single Go version from the go.mod toolchain via the shared go-check workflow):
+- `go-check / Build & Test`
+- `go-check / Integration Tests`
+- `go-check / E2E Tests`
+- `go-check / Smoke Tests (fast feedback)`
+- `go-check / golangci-lint`
+- `go-check / gosec`
+- `go-check / govulncheck`
+- `go-check / Fuzz (corpus replay)`
+- `go-check / License Scan`
+- `drift / Template drift`
 
 #### Code Review Requirements
 - [x] Require pull request reviews before merging

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Cron spec parser and job scheduler for Go (successor to robfig/cron).
 
 | Attribute | Value |
 |-----------|-------|
-| Language | Go 1.25+ (CI tests the go.mod toolchain, currently go1.27.0) |
+| Language | Go 1.26+ (two most recent Go releases; CI tests the go.mod toolchain, currently go1.27.0) |
 | Module | `github.com/netresearch/go-cron` |
 | Type | Library (zero external dependencies) |
 | API | Drop-in replacement for `robfig/cron/v3` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Cron spec parser and job scheduler for Go (successor to robfig/cron).
 
 | Attribute | Value |
 |-----------|-------|
-| Language | Go 1.25+ (CI tests 1.25.x + 1.26.x) |
+| Language | Go 1.25+ (CI tests the go.mod toolchain, currently go1.27.0) |
 | Module | `github.com/netresearch/go-cron` |
 | Type | Library (zero external dependencies) |
 | API | Drop-in replacement for `robfig/cron/v3` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Originally based on [robfig/cron](https://github.com/robfig/cron).
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING**: minimum supported Go version raised from 1.25 to 1.26 (Go release policy: two most recent releases, now 1.26 + 1.27); toolchain updated to go1.27.0
+
 ### Planned for v2
 - Context-aware Job interface with graceful shutdown support
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Enhancement suggestions are welcome! Please:
 
 ### Prerequisites
 
-- Go 1.25 or later
+- Go 1.26 or later
 - golangci-lint (for linting)
 - make (for build automation)
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A production-grade cron job scheduler for Go — drop-in replacement for [robfig
 | Context support | None | Per-entry context, `FuncJobWithContext` |
 | Resilience | None | Retry, circuit breaker, timeout, rate limiting |
 | Observability | None | Hooks for metrics (Prometheus, etc.) |
-| Go version | Stuck on 1.13 | Go 1.25+ with modern toolchain |
+| Go version | Stuck on 1.13 | Go 1.26+ with modern toolchain |
 
 ## Installation
 
@@ -46,7 +46,7 @@ import cron "github.com/netresearch/go-cron"
 ```
 
 > [!NOTE]
-> Requires Go 1.25 or later.
+> Requires Go 1.26 or later.
 
 ## Migrating from robfig/cron
 

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -138,7 +138,7 @@ func benchmarkCronWithJobs(b *testing.B, numJobs int) {
 	c := New()
 	job := FuncJob(func() {})
 
-	for i := 0; i < numJobs; i++ {
+	for range numJobs {
 		c.AddJob("* * * * *", job)
 	}
 

--- a/chain_test.go
+++ b/chain_test.go
@@ -74,13 +74,13 @@ type testLogCapture struct {
 	mu         sync.Mutex
 }
 
-func (l *testLogCapture) Info(msg string, keysAndValues ...interface{}) {
+func (l *testLogCapture) Info(msg string, keysAndValues ...any) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.infoCalls = append(l.infoCalls, msg)
 }
 
-func (l *testLogCapture) Error(err error, msg string, keysAndValues ...interface{}) {
+func (l *testLogCapture) Error(err error, msg string, keysAndValues ...any) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.errorCalls = append(l.errorCalls, msg)
@@ -328,7 +328,7 @@ func TestChainDelayIfStillRunning(t *testing.T) {
 		close(j.canProceed)
 
 		// Wait for both jobs to complete
-		for i := 0; i < 2; i++ {
+		for i := range 2 {
 			select {
 			case <-j.onDone:
 			case <-time.After(5 * time.Second):
@@ -508,12 +508,10 @@ func TestSkipIfStillRunning_Skip10JobsOnRapidFire(t *testing.T) {
 	var wrappersDone sync.WaitGroup
 
 	// Fire 11 jobs rapidly
-	for i := 0; i < 11; i++ {
-		wrappersDone.Add(1)
-		go func() {
-			defer wrappersDone.Done()
+	for range 11 {
+		wrappersDone.Go(func() {
 			wrappedJob.Run()
-		}()
+		})
 	}
 
 	// Wait for first job to start (it will hold the semaphore)
@@ -601,7 +599,7 @@ func TestSkipIfStillRunning_DifferentJobsIndependent(t *testing.T) {
 	var wrappersDone sync.WaitGroup
 
 	// Fire 11 jobs for each wrapped job
-	for i := 0; i < 11; i++ {
+	for range 11 {
 		wrappersDone.Add(2)
 		go func() {
 			defer wrappersDone.Done()
@@ -803,11 +801,11 @@ func TestChainTimeout(t *testing.T) {
 	})
 
 	t.Run("callback invoked on timeout", func(t *testing.T) {
-		var callbackCalled int32
+		var callbackCalled atomic.Int32
 		var callbackTimeout time.Duration
 
 		callback := func(timeout time.Duration) {
-			atomic.AddInt32(&callbackCalled, 1)
+			callbackCalled.Add(1)
 			callbackTimeout = timeout
 		}
 
@@ -819,7 +817,7 @@ func TestChainTimeout(t *testing.T) {
 		wrappedJob.Run()
 
 		// Callback should have been invoked
-		if c := atomic.LoadInt32(&callbackCalled); c != 1 {
+		if c := callbackCalled.Load(); c != 1 {
 			t.Errorf("expected callback to be called once, got %d", c)
 		}
 		if callbackTimeout != 5*time.Millisecond {
@@ -835,10 +833,10 @@ func TestChainTimeout(t *testing.T) {
 	})
 
 	t.Run("callback not invoked when job completes in time", func(t *testing.T) {
-		var callbackCalled int32
+		var callbackCalled atomic.Int32
 
 		callback := func(timeout time.Duration) {
-			atomic.AddInt32(&callbackCalled, 1)
+			callbackCalled.Add(1)
 		}
 
 		var j countJob
@@ -847,7 +845,7 @@ func TestChainTimeout(t *testing.T) {
 		wrappedJob.Run()
 
 		// Callback should NOT have been invoked
-		if c := atomic.LoadInt32(&callbackCalled); c != 0 {
+		if c := callbackCalled.Load(); c != 0 {
 			t.Errorf("expected callback not to be called, got %d calls", c)
 		}
 	})
@@ -858,11 +856,11 @@ func TestChainTimeout(t *testing.T) {
 // chain.go:418 where ctx.Err() == context.DeadlineExceeded could be negated.
 func TestTimeoutWithContextCancellation(t *testing.T) {
 	t.Run("callback not invoked on context cancellation", func(t *testing.T) {
-		var callbackCalled int32
+		var callbackCalled atomic.Int32
 		var errorLogged int32
 
 		callback := func(timeout time.Duration) {
-			atomic.AddInt32(&callbackCalled, 1)
+			callbackCalled.Add(1)
 		}
 
 		logger := &testLogCapture{}
@@ -908,7 +906,7 @@ func TestTimeoutWithContextCancellation(t *testing.T) {
 		}
 
 		// Callback should NOT be called because context was canceled, not timed out
-		if c := atomic.LoadInt32(&callbackCalled); c != 0 {
+		if c := callbackCalled.Load(); c != 0 {
 			t.Errorf("expected callback NOT called on cancellation, got %d calls", c)
 		}
 
@@ -921,10 +919,10 @@ func TestTimeoutWithContextCancellation(t *testing.T) {
 	})
 
 	t.Run("callback invoked on actual timeout", func(t *testing.T) {
-		var callbackCalled int32
+		var callbackCalled atomic.Int32
 
 		callback := func(timeout time.Duration) {
-			atomic.AddInt32(&callbackCalled, 1)
+			callbackCalled.Add(1)
 		}
 
 		logger := &testLogCapture{}
@@ -949,7 +947,7 @@ func TestTimeoutWithContextCancellation(t *testing.T) {
 		}
 
 		// Callback SHOULD be called because job actually timed out
-		if c := atomic.LoadInt32(&callbackCalled); c != 1 {
+		if c := callbackCalled.Load(); c != 1 {
 			t.Errorf("expected callback called once on timeout, got %d calls", c)
 		}
 
@@ -1099,7 +1097,7 @@ func TestJitter_Distribution(t *testing.T) {
 	iterations := 20
 	var totalDelay time.Duration
 
-	for i := 0; i < iterations; i++ {
+	for range iterations {
 		job := FuncJob(func() {})
 		wrappedJob := NewChain(Jitter(maxJitter)).Then(job)
 
@@ -1229,11 +1227,11 @@ func TestRecoverWithNonErrorPanic(t *testing.T) {
 
 // TestTimeoutWithContext_CallbackOnTimeout tests that RunWithContext fires onTimeout callback.
 func TestTimeoutWithContext_CallbackOnTimeout(t *testing.T) {
-	var callbackCalled int32
+	var callbackCalled atomic.Int32
 	var callbackDuration time.Duration
 
 	callback := func(timeout time.Duration) {
-		atomic.AddInt32(&callbackCalled, 1)
+		callbackCalled.Add(1)
 		callbackDuration = timeout
 	}
 
@@ -1262,7 +1260,7 @@ func TestTimeoutWithContext_CallbackOnTimeout(t *testing.T) {
 		t.Fatal("timeout waiting for abandoned goroutine")
 	}
 
-	if c := atomic.LoadInt32(&callbackCalled); c != 1 {
+	if c := callbackCalled.Load(); c != 1 {
 		t.Errorf("expected callback called once, got %d", c)
 	}
 	if callbackDuration != timeout {

--- a/clock_test.go
+++ b/clock_test.go
@@ -275,11 +275,9 @@ func TestFakeClockBlockUntil(t *testing.T) {
 
 	// BlockUntil with 1 timer
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		clock.BlockUntil(1)
-		wg.Done()
-	}()
+	})
 
 	// Create a timer
 	clock.NewTimer(time.Hour)
@@ -362,7 +360,7 @@ func TestFakeClockConcurrency(t *testing.T) {
 	timerCount := 100
 
 	// Create many timers concurrently
-	for i := 0; i < timerCount; i++ {
+	for i := range timerCount {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()

--- a/cron_test.go
+++ b/cron_test.go
@@ -479,12 +479,10 @@ func TestIsRunningConcurrent(t *testing.T) {
 
 	// Concurrent reads should be safe
 	var wg sync.WaitGroup
-	for i := 0; i < 100; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 100 {
+		wg.Go(func() {
 			_ = cron.IsRunning()
-		}()
+		})
 	}
 	wg.Wait()
 }
@@ -1194,7 +1192,7 @@ func TestWithSecondsOption(t *testing.T) {
 // TestEntryRunWithChain tests fix for issue #551
 // Entry.Run() should execute through the chain wrappers
 func TestEntryRunWithChain(t *testing.T) {
-	var callCount int64
+	var callCount atomic.Int64
 	var mu sync.Mutex
 
 	// Create cron with SkipIfStillRunning to test chain behavior
@@ -1206,7 +1204,7 @@ func TestEntryRunWithChain(t *testing.T) {
 	// Add a job that blocks and counts calls
 	_, err := cron.AddFunc("* * * * * *", func() {
 		mu.Lock()
-		atomic.AddInt64(&callCount, 1)
+		callCount.Add(1)
 		mu.Unlock()
 		time.Sleep(100 * time.Millisecond)
 	})
@@ -1233,13 +1231,13 @@ func TestEntryRunWithChain(t *testing.T) {
 	// Wait for first job to complete
 	time.Sleep(150 * time.Millisecond)
 
-	count := atomic.LoadInt64(&callCount)
+	count := callCount.Load()
 	if count != 1 {
 		t.Errorf("Entry.Run() with SkipIfStillRunning: expected 1 call, got %d (chain not respected)", count)
 	}
 
 	// Test 2: Entry.Job.Run() bypasses chain (documenting existing behavior)
-	atomic.StoreInt64(&callCount, 0)
+	callCount.Store(0)
 
 	// Start job via Entry.Job.Run() (bypasses chain)
 	go entry.Job.Run()
@@ -1251,7 +1249,7 @@ func TestEntryRunWithChain(t *testing.T) {
 	// Wait for both to complete
 	time.Sleep(150 * time.Millisecond)
 
-	count = atomic.LoadInt64(&callCount)
+	count = callCount.Load()
 	if count != 2 {
 		t.Errorf("Entry.Job.Run() (bypass chain): expected 2 calls, got %d", count)
 	}
@@ -1346,7 +1344,7 @@ func TestFakeClock_EverySecondSchedule(t *testing.T) {
 	fakeClock.BlockUntil(1)
 
 	// Advance 5 seconds
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		fakeClock.Advance(time.Second)
 		time.Sleep(5 * time.Millisecond) // Let goroutines run
 		if i < 4 {
@@ -1421,7 +1419,7 @@ func TestFakeClock_MultipleJobsDifferentIntervals(t *testing.T) {
 	fakeClock.BlockUntil(1)
 
 	// Advance 10 seconds total
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		fakeClock.Advance(time.Second)
 		time.Sleep(5 * time.Millisecond)
 		if i < 9 {
@@ -1854,7 +1852,7 @@ func TestIndexCompaction(t *testing.T) {
 	// Compaction triggers when: deletions >= 1000 AND deletions > currentSize
 	// After 1000 deletions, currentSize = 100, so 1000 > 100 triggers compaction.
 	// Then we delete 90 more, so indexDeletions ends at 90.
-	for i := 0; i < indexCompactionThreshold+90; i++ {
+	for i := range indexCompactionThreshold + 90 {
 		c.Remove(ids[i])
 	}
 
@@ -1906,7 +1904,7 @@ func TestIndexCompactionBoundaryCurrentSizeZero(t *testing.T) {
 	}
 
 	// Remove all entries
-	for i := 0; i < totalEntries; i++ {
+	for i := range totalEntries {
 		c.Remove(ids[i])
 	}
 
@@ -1949,7 +1947,7 @@ func TestIndexCompactionBoundaryDeletionsEqualSize(t *testing.T) {
 	}
 
 	// Remove exactly 1000 entries (reaching threshold but not exceeding currentSize)
-	for i := 0; i < indexCompactionThreshold; i++ {
+	for i := range indexCompactionThreshold {
 		c.Remove(ids[i])
 	}
 
@@ -2001,7 +1999,7 @@ func TestIndexCompactionBoundaryDeletionsEqualSizeExplicit(t *testing.T) {
 	total := 2 * indexCompactionThreshold
 	ids := make([]EntryID, total)
 
-	for i := 0; i < total; i++ {
+	for i := range total {
 		id, err := c.AddFunc("@every 1s", func() {}, WithName(fmt.Sprintf("explicit-%d", i)))
 		if err != nil {
 			t.Fatalf("failed to add job %d: %v", i, err)
@@ -2018,7 +2016,7 @@ func TestIndexCompactionBoundaryDeletionsEqualSizeExplicit(t *testing.T) {
 	}
 
 	// Delete exactly threshold entries
-	for i := 0; i < indexCompactionThreshold; i++ {
+	for i := range indexCompactionThreshold {
 		c.Remove(ids[i])
 	}
 
@@ -2286,7 +2284,7 @@ func TestWithContext_PropagatesContext(t *testing.T) {
 
 	c := New(WithClock(fc), WithContext(baseCtx))
 
-	var receivedValue interface{}
+	var receivedValue any
 	started := make(chan struct{})
 
 	c.AddJob("@every 1s", FuncJobWithContext(func(ctx context.Context) {
@@ -2463,11 +2461,11 @@ func TestRunOnce_BasicExecution(t *testing.T) {
 	fc := NewFakeClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
 	c := New(WithClock(fc), WithParser(secondParser))
 
-	var executions int32
+	var executions atomic.Int32
 	executed := make(chan struct{}, 1)
 
 	id, err := c.AddFunc("* * * * * *", func() {
-		atomic.AddInt32(&executions, 1)
+		executions.Add(1)
 		select {
 		case executed <- struct{}{}:
 		default:
@@ -2518,7 +2516,7 @@ func TestRunOnce_BasicExecution(t *testing.T) {
 	fc.Advance(2 * time.Second)
 	time.Sleep(50 * time.Millisecond)
 
-	if count := atomic.LoadInt32(&executions); count != 1 {
+	if count := executions.Load(); count != 1 {
 		t.Errorf("expected exactly 1 execution, got %d", count)
 	}
 }
@@ -2528,9 +2526,9 @@ func TestRunOnce_WithJobOption(t *testing.T) {
 	fc := NewFakeClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
 	c := New(WithClock(fc), WithParser(secondParser))
 
-	var executions int32
+	var executions atomic.Int32
 	job := FuncJob(func() {
-		atomic.AddInt32(&executions, 1)
+		executions.Add(1)
 	})
 
 	id, err := c.AddJob("* * * * * *", job, WithRunOnce())
@@ -2554,7 +2552,7 @@ func TestRunOnce_WithJobOption(t *testing.T) {
 	fc.Advance(3 * time.Second)
 	time.Sleep(50 * time.Millisecond)
 
-	if count := atomic.LoadInt32(&executions); count != 1 {
+	if count := executions.Load(); count != 1 {
 		t.Errorf("expected 1 execution, got %d", count)
 	}
 }
@@ -2610,11 +2608,11 @@ func TestRunOnce_WithRunImmediately(t *testing.T) {
 	fc := NewFakeClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
 	c := New(WithClock(fc))
 
-	var executions int32
+	var executions atomic.Int32
 	executed := make(chan struct{}, 1)
 
 	id, err := c.AddFunc("@hourly", func() {
-		atomic.AddInt32(&executions, 1)
+		executions.Add(1)
 		select {
 		case executed <- struct{}{}:
 		default:
@@ -2643,7 +2641,7 @@ func TestRunOnce_WithRunImmediately(t *testing.T) {
 	}
 
 	// Verify only one execution
-	if count := atomic.LoadInt32(&executions); count != 1 {
+	if count := executions.Load(); count != 1 {
 		t.Errorf("expected 1 execution, got %d", count)
 	}
 }
@@ -2653,9 +2651,9 @@ func TestAddOnceFunc(t *testing.T) {
 	fc := NewFakeClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
 	c := New(WithClock(fc), WithParser(secondParser))
 
-	var executions int32
+	var executions atomic.Int32
 	id, err := c.AddOnceFunc("* * * * * *", func() {
-		atomic.AddInt32(&executions, 1)
+		executions.Add(1)
 	})
 	if err != nil {
 		t.Fatalf("AddOnceFunc failed: %v", err)
@@ -2676,7 +2674,7 @@ func TestAddOnceFunc(t *testing.T) {
 	fc.Advance(2 * time.Second)
 	time.Sleep(50 * time.Millisecond)
 
-	if count := atomic.LoadInt32(&executions); count != 1 {
+	if count := executions.Load(); count != 1 {
 		t.Errorf("expected 1 execution, got %d", count)
 	}
 }
@@ -2686,9 +2684,9 @@ func TestAddOnceJob(t *testing.T) {
 	fc := NewFakeClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
 	c := New(WithClock(fc), WithParser(secondParser))
 
-	var executions int32
+	var executions atomic.Int32
 	job := FuncJob(func() {
-		atomic.AddInt32(&executions, 1)
+		executions.Add(1)
 	})
 
 	id, err := c.AddOnceJob("* * * * * *", job)
@@ -2707,7 +2705,7 @@ func TestAddOnceJob(t *testing.T) {
 		t.Error("AddOnceJob entry should be removed after execution")
 	}
 
-	if count := atomic.LoadInt32(&executions); count != 1 {
+	if count := executions.Load(); count != 1 {
 		t.Errorf("expected 1 execution, got %d", count)
 	}
 }
@@ -2717,9 +2715,9 @@ func TestScheduleOnceJob(t *testing.T) {
 	fc := NewFakeClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
 	c := New(WithClock(fc))
 
-	var executions int32
+	var executions atomic.Int32
 	job := FuncJob(func() {
-		atomic.AddInt32(&executions, 1)
+		executions.Add(1)
 	})
 
 	id, err := c.ScheduleOnceJob(Every(time.Second), job)
@@ -2741,7 +2739,7 @@ func TestScheduleOnceJob(t *testing.T) {
 	fc.Advance(3 * time.Second)
 	time.Sleep(50 * time.Millisecond)
 
-	if count := atomic.LoadInt32(&executions); count != 1 {
+	if count := executions.Load(); count != 1 {
 		t.Errorf("expected 1 execution, got %d", count)
 	}
 }
@@ -2860,9 +2858,9 @@ func TestRunOnce_RemoveBeforeExecution(t *testing.T) {
 	fc := NewFakeClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
 	c := New(WithClock(fc), WithParser(secondParser))
 
-	var executions int32
+	var executions atomic.Int32
 	id, _ := c.AddOnceFunc("* * * * * *", func() {
-		atomic.AddInt32(&executions, 1)
+		executions.Add(1)
 	})
 
 	c.Start()
@@ -2875,7 +2873,7 @@ func TestRunOnce_RemoveBeforeExecution(t *testing.T) {
 	fc.Advance(time.Second)
 	time.Sleep(50 * time.Millisecond)
 
-	if count := atomic.LoadInt32(&executions); count != 0 {
+	if count := executions.Load(); count != 0 {
 		t.Errorf("removed run-once job should not execute, got %d executions", count)
 	}
 }
@@ -2886,16 +2884,16 @@ func TestRunOnce_EntryCountDecrements(t *testing.T) {
 	c := New(WithClock(fc), WithParser(secondParser))
 
 	// Use atomic counter since both jobs fire at same time
-	var execCount int32
+	var execCount atomic.Int32
 	executed := make(chan struct{}, 2) // Buffered for 2 jobs
 
 	// Add 3 entries: 2 run-once, 1 regular
 	c.AddOnceFunc("* * * * * *", func() {
-		atomic.AddInt32(&execCount, 1)
+		execCount.Add(1)
 		executed <- struct{}{}
 	})
 	c.AddOnceFunc("* * * * * *", func() {
-		atomic.AddInt32(&execCount, 1)
+		execCount.Add(1)
 		executed <- struct{}{}
 	})
 	c.AddFunc("* * * * * *", func() {})
@@ -2912,7 +2910,7 @@ func TestRunOnce_EntryCountDecrements(t *testing.T) {
 	fc.Advance(time.Second)
 
 	// Wait for both run-once jobs with timeout
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		select {
 		case <-executed:
 		case <-time.After(time.Second):
@@ -2927,7 +2925,7 @@ func TestRunOnce_EntryCountDecrements(t *testing.T) {
 	}
 
 	// Verify both run-once jobs executed
-	if got := atomic.LoadInt32(&execCount); got != 2 {
+	if got := execCount.Load(); got != 2 {
 		t.Errorf("expected 2 run-once executions, got %d", got)
 	}
 }
@@ -3318,8 +3316,8 @@ func TestUpdateBeforeStart(t *testing.T) {
 			c := New(WithClock(clock), WithParser(secondParser))
 			defer c.Stop()
 
-			var runs int32
-			id, err := c.AddFunc("* * * * * *", func() { atomic.AddInt32(&runs, 1) })
+			var runs atomic.Int32
+			id, err := c.AddFunc("* * * * * *", func() { runs.Add(1) })
 			if err != nil {
 				t.Fatalf("add failed: %v", err)
 			}
@@ -3336,7 +3334,7 @@ func TestUpdateBeforeStart(t *testing.T) {
 			// Advance 4 seconds - should NOT trigger (schedule is every 5s)
 			clock.Advance(4 * time.Second)
 			time.Sleep(10 * time.Millisecond)
-			if got := atomic.LoadInt32(&runs); got != 0 {
+			if got := runs.Load(); got != 0 {
 				t.Errorf("expected 0 runs after 4s, got %d", got)
 			}
 
@@ -3344,7 +3342,7 @@ func TestUpdateBeforeStart(t *testing.T) {
 			clock.BlockUntil(1)
 			clock.Advance(1 * time.Second)
 			time.Sleep(10 * time.Millisecond)
-			if got := atomic.LoadInt32(&runs); got != 1 {
+			if got := runs.Load(); got != 1 {
 				t.Errorf("expected 1 run after 5s, got %d", got)
 			}
 		})
@@ -3943,9 +3941,9 @@ func TestRunAlreadyRunning(t *testing.T) {
 	fc := NewFakeClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
 	c := New(WithClock(fc))
 
-	var runs int32
+	var runs atomic.Int32
 	_, err := c.AddFunc("@every 1h", func() {
-		atomic.AddInt32(&runs, 1)
+		runs.Add(1)
 	})
 	if err != nil {
 		t.Fatalf("AddFunc returned error: %v", err)
@@ -4757,8 +4755,8 @@ func TestPauseEntryBeforeRunning(t *testing.T) {
 	c := New(WithClock(clock), WithParser(secondParser))
 	defer c.Stop()
 
-	var runs int32
-	id, err := c.AddFunc("* * * * * *", func() { atomic.AddInt32(&runs, 1) })
+	var runs atomic.Int32
+	id, err := c.AddFunc("* * * * * *", func() { runs.Add(1) })
 	if err != nil {
 		t.Fatalf("add failed: %v", err)
 	}
@@ -4773,7 +4771,7 @@ func TestPauseEntryBeforeRunning(t *testing.T) {
 	clock.Advance(time.Second)
 	time.Sleep(10 * time.Millisecond)
 
-	if n := atomic.LoadInt32(&runs); n != 0 {
+	if n := runs.Load(); n != 0 {
 		t.Errorf("expected 0 runs while paused, got %d", n)
 	}
 }
@@ -4784,8 +4782,8 @@ func TestPauseEntryWhileRunning(t *testing.T) {
 	c := New(WithClock(clock), WithParser(secondParser))
 	defer c.Stop()
 
-	var runs int32
-	id, err := c.AddFunc("* * * * * *", func() { atomic.AddInt32(&runs, 1) })
+	var runs atomic.Int32
+	id, err := c.AddFunc("* * * * * *", func() { runs.Add(1) })
 	if err != nil {
 		t.Fatalf("add failed: %v", err)
 	}
@@ -4795,7 +4793,7 @@ func TestPauseEntryWhileRunning(t *testing.T) {
 	clock.Advance(time.Second)
 	time.Sleep(10 * time.Millisecond)
 
-	if n := atomic.LoadInt32(&runs); n != 1 {
+	if n := runs.Load(); n != 1 {
 		t.Fatalf("expected 1 run before pause, got %d", n)
 	}
 
@@ -4808,7 +4806,7 @@ func TestPauseEntryWhileRunning(t *testing.T) {
 	clock.Advance(time.Second)
 	time.Sleep(10 * time.Millisecond)
 
-	if n := atomic.LoadInt32(&runs); n != 1 {
+	if n := runs.Load(); n != 1 {
 		t.Errorf("expected still 1 run after pausing, got %d", n)
 	}
 }
@@ -4819,8 +4817,8 @@ func TestResumeEntry(t *testing.T) {
 	c := New(WithClock(clock), WithParser(secondParser))
 	defer c.Stop()
 
-	var runs int32
-	id, err := c.AddFunc("* * * * * *", func() { atomic.AddInt32(&runs, 1) })
+	var runs atomic.Int32
+	id, err := c.AddFunc("* * * * * *", func() { runs.Add(1) })
 	if err != nil {
 		t.Fatalf("add failed: %v", err)
 	}
@@ -4836,7 +4834,7 @@ func TestResumeEntry(t *testing.T) {
 	clock.Advance(time.Second)
 	time.Sleep(10 * time.Millisecond)
 
-	if n := atomic.LoadInt32(&runs); n != 0 {
+	if n := runs.Load(); n != 0 {
 		t.Fatalf("expected 0 runs while paused, got %d", n)
 	}
 
@@ -4849,7 +4847,7 @@ func TestResumeEntry(t *testing.T) {
 	clock.Advance(time.Second)
 	time.Sleep(10 * time.Millisecond)
 
-	if n := atomic.LoadInt32(&runs); n != 1 {
+	if n := runs.Load(); n != 1 {
 		t.Errorf("expected 1 run after resume, got %d", n)
 	}
 }
@@ -4860,8 +4858,8 @@ func TestPauseEntryByName(t *testing.T) {
 	c := New(WithClock(clock), WithParser(secondParser))
 	defer c.Stop()
 
-	var runs int32
-	_, err := c.AddFunc("* * * * * *", func() { atomic.AddInt32(&runs, 1) }, WithName("my-job"))
+	var runs atomic.Int32
+	_, err := c.AddFunc("* * * * * *", func() { runs.Add(1) }, WithName("my-job"))
 	if err != nil {
 		t.Fatalf("add failed: %v", err)
 	}
@@ -4871,7 +4869,7 @@ func TestPauseEntryByName(t *testing.T) {
 	clock.Advance(time.Second)
 	time.Sleep(10 * time.Millisecond)
 
-	if n := atomic.LoadInt32(&runs); n != 1 {
+	if n := runs.Load(); n != 1 {
 		t.Fatalf("expected 1 run before pause, got %d", n)
 	}
 
@@ -4883,7 +4881,7 @@ func TestPauseEntryByName(t *testing.T) {
 	clock.Advance(time.Second)
 	time.Sleep(10 * time.Millisecond)
 
-	if n := atomic.LoadInt32(&runs); n != 1 {
+	if n := runs.Load(); n != 1 {
 		t.Errorf("expected still 1 run after pause by name, got %d", n)
 	}
 }
@@ -4894,8 +4892,8 @@ func TestResumeEntryByName(t *testing.T) {
 	c := New(WithClock(clock), WithParser(secondParser))
 	defer c.Stop()
 
-	var runs int32
-	_, err := c.AddFunc("* * * * * *", func() { atomic.AddInt32(&runs, 1) }, WithName("my-job"))
+	var runs atomic.Int32
+	_, err := c.AddFunc("* * * * * *", func() { runs.Add(1) }, WithName("my-job"))
 	if err != nil {
 		t.Fatalf("add failed: %v", err)
 	}
@@ -4910,7 +4908,7 @@ func TestResumeEntryByName(t *testing.T) {
 	clock.Advance(time.Second)
 	time.Sleep(10 * time.Millisecond)
 
-	if n := atomic.LoadInt32(&runs); n != 0 {
+	if n := runs.Load(); n != 0 {
 		t.Fatalf("expected 0 runs while paused, got %d", n)
 	}
 
@@ -4922,7 +4920,7 @@ func TestResumeEntryByName(t *testing.T) {
 	clock.Advance(time.Second)
 	time.Sleep(10 * time.Millisecond)
 
-	if n := atomic.LoadInt32(&runs); n != 1 {
+	if n := runs.Load(); n != 1 {
 		t.Errorf("expected 1 run after resume by name, got %d", n)
 	}
 }
@@ -5000,21 +4998,21 @@ func TestPausedEntryKeepsSchedule(t *testing.T) {
 	c := New(WithClock(clock), WithParser(secondParser))
 	defer c.Stop()
 
-	var runs int32
-	id, _ := c.AddFunc("* * * * * *", func() { atomic.AddInt32(&runs, 1) })
+	var runs atomic.Int32
+	id, _ := c.AddFunc("* * * * * *", func() { runs.Add(1) })
 	c.Start()
 	clock.BlockUntil(1)
 
 	c.PauseEntry(id)
 
 	// Advance 5 seconds while paused
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		clock.Advance(time.Second)
 		time.Sleep(5 * time.Millisecond)
 		clock.BlockUntil(1)
 	}
 
-	if n := atomic.LoadInt32(&runs); n != 0 {
+	if n := runs.Load(); n != 0 {
 		t.Fatalf("expected 0 runs while paused, got %d", n)
 	}
 
@@ -5024,7 +5022,7 @@ func TestPausedEntryKeepsSchedule(t *testing.T) {
 	clock.Advance(time.Second)
 	time.Sleep(10 * time.Millisecond)
 
-	if n := atomic.LoadInt32(&runs); n != 1 {
+	if n := runs.Load(); n != 1 {
 		t.Errorf("expected exactly 1 run after resume (no catch-up), got %d", n)
 	}
 }
@@ -5035,8 +5033,8 @@ func TestWithPausedOption(t *testing.T) {
 	c := New(WithClock(clock), WithParser(secondParser))
 	defer c.Stop()
 
-	var runs int32
-	id, _ := c.AddFunc("* * * * * *", func() { atomic.AddInt32(&runs, 1) }, WithPaused())
+	var runs atomic.Int32
+	id, _ := c.AddFunc("* * * * * *", func() { runs.Add(1) }, WithPaused())
 
 	if !c.IsEntryPaused(id) {
 		t.Fatal("entry should start paused with WithPaused option")
@@ -5047,7 +5045,7 @@ func TestWithPausedOption(t *testing.T) {
 	clock.Advance(time.Second)
 	time.Sleep(10 * time.Millisecond)
 
-	if n := atomic.LoadInt32(&runs); n != 0 {
+	if n := runs.Load(); n != 0 {
 		t.Fatalf("expected 0 runs while paused via WithPaused, got %d", n)
 	}
 
@@ -5056,7 +5054,7 @@ func TestWithPausedOption(t *testing.T) {
 	clock.Advance(time.Second)
 	time.Sleep(10 * time.Millisecond)
 
-	if n := atomic.LoadInt32(&runs); n != 1 {
+	if n := runs.Load(); n != 1 {
 		t.Errorf("expected 1 run after resuming WithPaused entry, got %d", n)
 	}
 }
@@ -5378,9 +5376,9 @@ func TestDSTFallBack_SchedulerDedup(t *testing.T) {
 
 	c := New(WithClock(clock), WithLocation(loc))
 
-	var runs int32
+	var runs atomic.Int32
 	c.AddFunc("30 1 * * *", func() {
-		atomic.AddInt32(&runs, 1)
+		runs.Add(1)
 	})
 
 	c.Start()
@@ -5392,7 +5390,7 @@ func TestDSTFallBack_SchedulerDedup(t *testing.T) {
 	clock.Advance(1 * time.Minute)
 	time.Sleep(20 * time.Millisecond)
 
-	if got := atomic.LoadInt32(&runs); got != 1 {
+	if got := runs.Load(); got != 1 {
 		t.Fatalf("expected 1 run after first occurrence, got %d", got)
 	}
 
@@ -5402,7 +5400,7 @@ func TestDSTFallBack_SchedulerDedup(t *testing.T) {
 	clock.Advance(2 * time.Hour)
 	time.Sleep(20 * time.Millisecond)
 
-	if got := atomic.LoadInt32(&runs); got != 1 {
+	if got := runs.Load(); got != 1 {
 		t.Errorf("expected exactly 1 run (DST dedup), got %d", got)
 	}
 }
@@ -5423,9 +5421,9 @@ func TestDSTFallBack_ConstantDelay(t *testing.T) {
 
 	c := New(WithClock(clock), WithLocation(loc))
 
-	var runs int32
+	var runs atomic.Int32
 	c.AddFunc("@every 30m", func() {
-		atomic.AddInt32(&runs, 1)
+		runs.Add(1)
 	})
 
 	c.Start()
@@ -5440,7 +5438,7 @@ func TestDSTFallBack_ConstantDelay(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	if got := atomic.LoadInt32(&runs); got < 5 {
+	if got := runs.Load(); got < 5 {
 		t.Errorf("expected @every 30m to fire at least 5 times in 3 hours, got %d", got)
 	}
 }
@@ -5461,9 +5459,9 @@ func TestDSTFallBack_PerScheduleTZ(t *testing.T) {
 
 	c := New(WithClock(clock), WithLocation(time.UTC))
 
-	var runs int32
+	var runs atomic.Int32
 	c.AddFunc("TZ=America/New_York 30 1 * * *", func() {
-		atomic.AddInt32(&runs, 1)
+		runs.Add(1)
 	})
 
 	c.Start()
@@ -5475,7 +5473,7 @@ func TestDSTFallBack_PerScheduleTZ(t *testing.T) {
 	clock.Advance(1 * time.Minute)
 	time.Sleep(20 * time.Millisecond)
 
-	if got := atomic.LoadInt32(&runs); got != 1 {
+	if got := runs.Load(); got != 1 {
 		t.Fatalf("expected 1 run after first occurrence, got %d", got)
 	}
 
@@ -5485,7 +5483,7 @@ func TestDSTFallBack_PerScheduleTZ(t *testing.T) {
 	clock.Advance(2 * time.Hour)
 	time.Sleep(20 * time.Millisecond)
 
-	if got := atomic.LoadInt32(&runs); got != 1 {
+	if got := runs.Load(); got != 1 {
 		t.Errorf("expected exactly 1 run with per-schedule TZ dedup, got %d", got)
 	}
 }
@@ -5520,9 +5518,9 @@ func TestDSTFallBack_ScheduleExhaustedAfterSkip(t *testing.T) {
 
 	c := New(WithClock(clock), WithLocation(loc))
 
-	var runs int32
+	var runs atomic.Int32
 	c.Schedule(sched, FuncJob(func() {
-		atomic.AddInt32(&runs, 1)
+		runs.Add(1)
 	}))
 
 	c.Start()
@@ -5534,7 +5532,7 @@ func TestDSTFallBack_ScheduleExhaustedAfterSkip(t *testing.T) {
 	clock.Advance(1 * time.Minute)
 	time.Sleep(20 * time.Millisecond)
 
-	if got := atomic.LoadInt32(&runs); got != 1 {
+	if got := runs.Load(); got != 1 {
 		t.Fatalf("expected 1 run, got %d", got)
 	}
 
@@ -5545,7 +5543,7 @@ func TestDSTFallBack_ScheduleExhaustedAfterSkip(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 
 	// Job must not have fired again.
-	if got := atomic.LoadInt32(&runs); got != 1 {
+	if got := runs.Load(); got != 1 {
 		t.Errorf("expected exactly 1 run after schedule exhaustion, got %d", got)
 	}
 
@@ -5726,9 +5724,9 @@ func TestDrainAndUpsertCreatesWhenAbsent(t *testing.T) {
 	c.Start()
 	defer c.Stop()
 
-	var runs int32
+	var runs atomic.Int32
 	id, err := c.DrainAndUpsertJob("* * * * * *", FuncJob(func() {
-		atomic.AddInt32(&runs, 1)
+		runs.Add(1)
 	}), WithName("fresh"))
 	if err != nil {
 		t.Fatalf("DrainAndUpsertJob failed: %v", err)
@@ -5746,7 +5744,7 @@ func TestDrainAndUpsertCreatesWhenAbsent(t *testing.T) {
 	clock.BlockUntil(1)
 	clock.Advance(time.Second)
 	deadline := time.After(2 * time.Second)
-	for atomic.LoadInt32(&runs) == 0 {
+	for runs.Load() == 0 {
 		select {
 		case <-deadline:
 			t.Fatal("created job did not run")
@@ -5865,10 +5863,10 @@ func TestDrainAndUpsertSchedulerStopped(t *testing.T) {
 		t.Errorf("expected preserved ID, got %v != %v", id1, id2)
 	}
 
-	var runs int32
+	var runs atomic.Int32
 	// Re-point to a counting job, still stopped, then start and confirm it fires.
 	if _, err := c.DrainAndUpsertJob("* * * * * *", FuncJob(func() {
-		atomic.AddInt32(&runs, 1)
+		runs.Add(1)
 	}), WithName("stopped")); err != nil {
 		t.Fatalf("second DrainAndUpsertJob failed: %v", err)
 	}
@@ -5877,7 +5875,7 @@ func TestDrainAndUpsertSchedulerStopped(t *testing.T) {
 	clock.BlockUntil(1)
 	clock.Advance(time.Second)
 	deadline := time.After(2 * time.Second)
-	for atomic.LoadInt32(&runs) == 0 {
+	for runs.Load() == 0 {
 		select {
 		case <-deadline:
 			t.Fatal("job did not fire after Start")

--- a/doc.go
+++ b/doc.go
@@ -16,7 +16,7 @@ Import it in your program as:
 
 	import "github.com/netresearch/go-cron"
 
-It requires Go 1.25 or later.
+It requires Go 1.26 or later.
 
 # Usage
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -45,7 +45,7 @@ import cron "github.com/netresearch/go-cron"
 
 ### What Go versions are supported?
 
-Go 1.25 and later. We follow Go's [release policy](https://go.dev/doc/devel/release#policy) and support the two most recent major versions.
+Go 1.26 and later. We follow Go's [release policy](https://go.dev/doc/devel/release#policy) and support the two most recent major versions.
 
 ### Does this library have any dependencies?
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -54,7 +54,7 @@ Go 1.26 and later. We follow Go's [release policy](https://go.dev/doc/devel/rele
 ```
 module github.com/netresearch/go-cron
 
-go 1.25
+go 1.26
 ```
 
 This means:

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -323,7 +323,7 @@ c := cron.New(cron.WithLogger(
 
 - [ ] Update import path to `github.com/netresearch/go-cron`
 - [ ] Update go.mod with `go get github.com/netresearch/go-cron@latest`
-- [ ] Verify Go version is 1.25+
+- [ ] Verify Go version is 1.26+
 - [ ] Review timezone handling for empty/invalid timezone cases
 - [ ] Update `entry.Job.Run()` calls to `entry.Run()` if chain behavior is expected
 - [ ] Review cron expressions for step validation (`*/60` style patterns)

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -35,7 +35,7 @@ The API is 100% compatible with robfig/cron v3 — no code changes required for 
 | Library | Minimum Go Version |
 |---------|-------------------|
 | robfig/cron v3 | Go 1.13 |
-| netresearch/go-cron | Go 1.25 |
+| netresearch/go-cron | Go 1.26 |
 
 ## Behavioral Differences
 

--- a/docs/PROJECT_INDEX.md
+++ b/docs/PROJECT_INDEX.md
@@ -7,7 +7,7 @@
 | Attribute | Value |
 |-----------|-------|
 | **Module** | `github.com/netresearch/go-cron` |
-| **Go Version** | 1.25+ |
+| **Go Version** | 1.26+ |
 | **Total Lines** | ~5,870 |
 | **Test Coverage** | Comprehensive (unit, fuzz, benchmark, integration) |
 | **License** | MIT |

--- a/example_test.go
+++ b/example_test.go
@@ -462,7 +462,7 @@ func ExampleTimeout_cancellable() {
 	// Wrap the worker in a FuncJob
 	c.Schedule(cron.Every(time.Minute), cron.FuncJob(func() {
 		defer close(worker.done)
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			select {
 			case <-worker.cancel:
 				fmt.Println("Job canceled cleanly")
@@ -1005,7 +1005,7 @@ func ExampleNewParser_hashStep() {
 	from := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 
 	// Get the first 4 execution times
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		next := schedule.Next(from)
 		fmt.Printf("%s\n", next.Format("15:04"))
 		from = next

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/netresearch/go-cron
 
 go 1.25
 
-toolchain go1.26.2
+toolchain go1.27.0
 
 retract (
 	v1.3.0 // Retraction-only release; use v0.6.x

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/netresearch/go-cron
 
-go 1.25
+go 1.26
 
 toolchain go1.27.0
 

--- a/hash_test.go
+++ b/hash_test.go
@@ -151,7 +151,7 @@ func TestHashWithStep(t *testing.T) {
 	from := time.Date(2024, 1, 1, 0, 0, 0, 0, loc)
 	times := make([]time.Time, 4)
 	current := from
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		times[i] = schedule.Next(current)
 		current = times[i]
 	}
@@ -177,7 +177,7 @@ func TestHashWithRange(t *testing.T) {
 	}
 
 	from := time.Date(2024, 1, 1, 0, 0, 0, 0, loc)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		next := schedule.Next(from)
 		if next.Minute() < 0 || next.Minute() > 29 {
 			t.Errorf("Minute %d outside range 0-29", next.Minute())
@@ -202,7 +202,7 @@ func TestHashWithRangeAndStep(t *testing.T) {
 	// Get first few execution times and verify they're 10 minutes apart
 	times := make([]time.Time, 3)
 	current := from
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		times[i] = schedule.Next(current)
 		if times[i].Minute() > 30 {
 			t.Errorf("Minute %d exceeds range max 30", times[i].Minute())
@@ -303,9 +303,9 @@ func TestHashFieldConcurrent(t *testing.T) {
 	parser := NewParser(Minute | Hour | Dom | Month | Dow | Descriptor | Hash)
 
 	done := make(chan bool)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		go func(id int) {
-			for j := 0; j < 100; j++ {
+			for range 100 {
 				key := "job" + string(rune('0'+id))
 				schedule, err := parser.ParseWithHashKey("H * * * *", key)
 				if err != nil {
@@ -321,7 +321,7 @@ func TestHashFieldConcurrent(t *testing.T) {
 		}(i)
 	}
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		<-done
 	}
 }

--- a/heap_test.go
+++ b/heap_test.go
@@ -232,7 +232,7 @@ func BenchmarkHeapPush(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		h := &entryHeap{}
 		heap.Init(h)
-		for j := 0; j < 1000; j++ {
+		for j := range 1000 {
 			e := &Entry{
 				ID:        EntryID(j),
 				Next:      now.Add(time.Duration(j) * time.Second),
@@ -249,7 +249,7 @@ func BenchmarkHeapPopPush(b *testing.B) {
 	heap.Init(h)
 
 	// Pre-populate with 1000 entries
-	for j := 0; j < 1000; j++ {
+	for j := range 1000 {
 		e := &Entry{
 			ID:        EntryID(j),
 			Next:      now.Add(time.Duration(j) * time.Second),
@@ -273,7 +273,7 @@ func BenchmarkHeapUpdate(b *testing.B) {
 
 	// Pre-populate with 1000 entries
 	entries := make([]*Entry, 1000)
-	for j := 0; j < 1000; j++ {
+	for j := range 1000 {
 		e := &Entry{
 			ID:        EntryID(j),
 			Next:      now.Add(time.Duration(j) * time.Second),
@@ -541,7 +541,7 @@ func BenchmarkRemoveAtWithIndex(b *testing.B) {
 	h := &entryHeap{}
 	heap.Init(h)
 	index := make(map[EntryID]*Entry)
-	for j := 0; j < size; j++ {
+	for j := range size {
 		e := &Entry{
 			ID:        EntryID(j + 1),
 			Next:      now.Add(time.Duration(j) * time.Second),

--- a/introspect_test.go
+++ b/introspect_test.go
@@ -743,9 +743,9 @@ func TestIntrospectionConcurrent(t *testing.T) {
 	end := time.Date(2024, 6, 16, 10, 0, 0, 0, time.UTC)
 
 	done := make(chan bool)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		go func() {
-			for j := 0; j < 100; j++ {
+			for range 100 {
 				_ = NextN(schedule, start, 10)
 				_ = PrevN(schedule, start, 10)
 				_ = Between(schedule, start, end)
@@ -756,7 +756,7 @@ func TestIntrospectionConcurrent(t *testing.T) {
 		}()
 	}
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		<-done
 	}
 }

--- a/max_concurrent_test.go
+++ b/max_concurrent_test.go
@@ -19,7 +19,7 @@ func TestMaxConcurrent_LimitsParallelism(t *testing.T) {
 	wrapper := MaxConcurrent(limit)
 	var wg sync.WaitGroup
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		wg.Add(1)
 		wrapped := wrapper(FuncJob(func() {
 			defer wg.Done()
@@ -50,24 +50,24 @@ func TestMaxConcurrent_LimitsParallelism(t *testing.T) {
 }
 
 func TestMaxConcurrent_AllJobsComplete(t *testing.T) {
-	var completed int32
+	var completed atomic.Int32
 
 	wrapper := MaxConcurrent(2)
 	var wg sync.WaitGroup
 
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		wg.Add(1)
 		wrapped := wrapper(FuncJob(func() {
 			defer wg.Done()
 			time.Sleep(5 * time.Millisecond)
-			atomic.AddInt32(&completed, 1)
+			completed.Add(1)
 		}))
 		go wrapped.Run()
 	}
 
 	wg.Wait()
 
-	if got := atomic.LoadInt32(&completed); got != 20 {
+	if got := completed.Load(); got != 20 {
 		t.Errorf("expected 20 completed, got %d", got)
 	}
 }
@@ -103,7 +103,7 @@ func TestMaxConcurrent_SharedAcrossJobs(t *testing.T) {
 	var wg sync.WaitGroup
 
 	// Create multiple distinct jobs
-	for i := 0; i < 6; i++ {
+	for range 6 {
 		wg.Add(1)
 		job := FuncJob(func() {
 			defer wg.Done()
@@ -157,7 +157,7 @@ func TestMaxConcurrent_SingleSlot(t *testing.T) {
 
 	wrapper := MaxConcurrent(1)
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		wg.Add(1)
 		idx := i
 		wrapped := wrapper(FuncJob(func() {
@@ -221,23 +221,23 @@ func TestMaxConcurrentSkip_SkipsWhenFull(t *testing.T) {
 }
 
 func TestMaxConcurrentSkip_ExecutesWhenAvailable(t *testing.T) {
-	var completed int32
+	var completed atomic.Int32
 
 	wrapper := MaxConcurrentSkip(DiscardLogger, 5)
 
 	var wg sync.WaitGroup
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		wg.Add(1)
 		wrapped := wrapper(FuncJob(func() {
 			defer wg.Done()
-			atomic.AddInt32(&completed, 1)
+			completed.Add(1)
 		}))
 		wrapped.Run()
 	}
 
 	wg.Wait()
 
-	if got := atomic.LoadInt32(&completed); got != 5 {
+	if got := completed.Load(); got != 5 {
 		t.Errorf("expected 5 completed, got %d", got)
 	}
 }
@@ -280,7 +280,7 @@ func TestMaxConcurrentSkip_LimitsParallelism(t *testing.T) {
 
 	wrapper := MaxConcurrentSkip(DiscardLogger, limit)
 
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		wg.Add(1)
 		wrapped := wrapper(FuncJob(func() {
 			cur := atomic.AddInt32(&running, 1)
@@ -333,7 +333,7 @@ func TestMaxConcurrent_IntegrationWithCron(t *testing.T) {
 	)
 
 	// Add 5 jobs all triggering at the same time
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		c.AddFunc("@every 1h", func() {
 			cur := atomic.AddInt32(&running, 1)
 			mu.Lock()

--- a/max_entries_test.go
+++ b/max_entries_test.go
@@ -79,7 +79,7 @@ func TestWithMaxEntries_ZeroMeansUnlimited(t *testing.T) {
 	c := New() // Default is 0 (unlimited)
 
 	// Should be able to add many entries
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		_, err := c.AddFunc("* * * * *", func() {})
 		if err != nil {
 			t.Fatalf("AddFunc failed at iteration %d: %v", i, err)
@@ -94,7 +94,7 @@ func TestWithMaxEntries_ZeroMeansUnlimited(t *testing.T) {
 func TestWithMaxEntries_ExplicitZeroIsUnlimited(t *testing.T) {
 	c := New(WithMaxEntries(0)) // Explicit 0 = unlimited
 
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		_, err := c.AddFunc("* * * * *", func() {})
 		if err != nil {
 			t.Fatalf("AddFunc failed at iteration %d: %v", i, err)
@@ -386,7 +386,7 @@ func TestCompactionThresholdBoundary(t *testing.T) {
 	// Add entries
 	const numEntries = 100
 	ids := make([]EntryID, numEntries)
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		id, _ := c.AddFunc("* * * * *", func() {})
 		ids[i] = id
 	}
@@ -398,7 +398,7 @@ func TestCompactionThresholdBoundary(t *testing.T) {
 
 	// Remove entries one at a time - should not trigger compaction yet
 	// because indexDeletions < indexCompactionThreshold (1000)
-	for i := 0; i < numEntries/2; i++ {
+	for i := range numEntries / 2 {
 		c.Remove(ids[i])
 	}
 

--- a/missed_test.go
+++ b/missed_test.go
@@ -289,7 +289,7 @@ func TestMissedMaxRunsLimit(t *testing.T) {
 	now := time.Date(2026, 1, 18, 12, 0, 0, 0, time.UTC)
 	clock := NewFakeClock(now)
 
-	var calls int64
+	var calls atomic.Int64
 
 	c := New(
 		WithClock(clock),
@@ -300,7 +300,7 @@ func TestMissedMaxRunsLimit(t *testing.T) {
 	// Should only run 100 times (capped)
 	lastRun := now.Add(-200 * time.Minute)
 	_, err := c.AddFunc("0 * * * * *", func() {
-		atomic.AddInt64(&calls, 1)
+		calls.Add(1)
 	},
 		WithPrev(lastRun),
 		WithMissedPolicy(MissedRunAll),
@@ -315,7 +315,7 @@ func TestMissedMaxRunsLimit(t *testing.T) {
 	// Wait for catch-up to run
 	time.Sleep(200 * time.Millisecond)
 
-	count := atomic.LoadInt64(&calls)
+	count := calls.Load()
 	if count > maxMissedRuns {
 		t.Errorf("MissedRunAll should be capped at %d, got %d calls", maxMissedRuns, count)
 	}

--- a/option_capacity_test.go
+++ b/option_capacity_test.go
@@ -95,7 +95,7 @@ func TestWithCapacity_BulkAdditions(t *testing.T) {
 		initialPtr := &c.entries
 
 		// Add entries up to capacity
-		for i := 0; i < capacity; i++ {
+		for i := range capacity {
 			_, err := c.AddFunc("@every 1h", func() {})
 			if err != nil {
 				t.Fatalf("failed to add entry %d: %v", i, err)
@@ -149,7 +149,7 @@ func BenchmarkWithCapacity_BulkAdd(b *testing.B) {
 	b.Run("without_capacity", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			c := New()
-			for j := 0; j < numEntries; j++ {
+			for range numEntries {
 				c.AddFunc("@every 1h", func() {})
 			}
 		}
@@ -158,7 +158,7 @@ func BenchmarkWithCapacity_BulkAdd(b *testing.B) {
 	b.Run("with_capacity", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			c := New(WithCapacity(numEntries))
-			for j := 0; j < numEntries; j++ {
+			for range numEntries {
 				c.AddFunc("@every 1h", func() {})
 			}
 		}
@@ -173,7 +173,7 @@ func BenchmarkWithCapacity_MapOperations(b *testing.B) {
 			b.Run("with_capacity", func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					c := New(WithCapacity(size))
-					for j := 0; j < size; j++ {
+					for range size {
 						c.AddFunc("@every 1h", func() {})
 					}
 					// Access all entries
@@ -184,7 +184,7 @@ func BenchmarkWithCapacity_MapOperations(b *testing.B) {
 			b.Run("without_capacity", func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					c := New()
-					for j := 0; j < size; j++ {
+					for range size {
 						c.AddFunc("@every 1h", func() {})
 					}
 					// Access all entries

--- a/option_test.go
+++ b/option_test.go
@@ -193,7 +193,7 @@ func TestWithMinEveryInterval_SubSecondExecution(t *testing.T) {
 	defer c.Stop()
 
 	// Advance time by 350ms - should trigger ~3 executions
-	for i := 0; i < 35; i++ {
+	for range 35 {
 		clock.Advance(10 * time.Millisecond)
 		time.Sleep(1 * time.Millisecond) // Let scheduler process
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -249,7 +249,7 @@ func TestWraparoundScheduleNextTime(t *testing.T) {
 
 		// Continue to verify the wraparound
 		times := []time.Time{next}
-		for i := 0; i < 4; i++ {
+		for range 4 {
 			next = sched.Next(next)
 			times = append(times, next)
 		}
@@ -283,7 +283,7 @@ func TestWraparoundScheduleNextTime(t *testing.T) {
 
 		// Continue through the year boundary
 		times := []time.Time{next}
-		for i := 0; i < 3; i++ {
+		for range 3 {
 			next = sched.Next(next)
 			times = append(times, next)
 		}
@@ -322,7 +322,7 @@ func TestWraparoundScheduleNextTime(t *testing.T) {
 
 		// Continue through the weekend
 		times := []time.Time{next}
-		for i := 0; i < 3; i++ {
+		for range 3 {
 			next = sched.Next(next)
 			times = append(times, next)
 		}
@@ -970,14 +970,14 @@ func TestParserWithCache(t *testing.T) {
 		specs := []string{"0 * * * *", "30 * * * *", "@hourly", "@daily"}
 
 		done := make(chan bool, 100)
-		for i := 0; i < 100; i++ {
+		for i := range 100 {
 			go func(idx int) {
 				_, _ = parser.Parse(specs[idx%len(specs)])
 				done <- true
 			}(i)
 		}
 
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			<-done
 		}
 	})

--- a/retry_observability_test.go
+++ b/retry_observability_test.go
@@ -50,7 +50,7 @@ func TestRetryWithBackoff_Callback_SuccessFirstAttempt(t *testing.T) {
 func TestRetryWithBackoff_Callback_RetryThenSuccess(t *testing.T) {
 	var events []RetryAttempt
 	var mu sync.Mutex
-	var attempts int32
+	var attempts atomic.Int32
 
 	wrapped := RetryWithBackoff(DiscardLogger, 3, 10*time.Millisecond, time.Second, 2.0,
 		WithRetryCallback(func(a RetryAttempt) {
@@ -59,7 +59,7 @@ func TestRetryWithBackoff_Callback_RetryThenSuccess(t *testing.T) {
 			mu.Unlock()
 		}),
 	)(FuncJob(func() {
-		count := atomic.AddInt32(&attempts, 1)
+		count := attempts.Add(1)
 		if count < 3 {
 			panic("transient")
 		}
@@ -142,11 +142,11 @@ func TestRetryWithBackoff_Callback_Exhausted(t *testing.T) {
 
 func TestRetryWithBackoff_NoCallback(t *testing.T) {
 	// Verify RetryWithBackoff works without callback (backward compat)
-	var attempts int32
+	var attempts atomic.Int32
 
 	wrapped := RetryWithBackoff(DiscardLogger, 3, 10*time.Millisecond, time.Second, 2.0)(
 		FuncJob(func() {
-			count := atomic.AddInt32(&attempts, 1)
+			count := attempts.Add(1)
 			if count < 2 {
 				panic("transient")
 			}
@@ -155,7 +155,7 @@ func TestRetryWithBackoff_NoCallback(t *testing.T) {
 
 	wrapped.Run()
 
-	if got := atomic.LoadInt32(&attempts); got != 2 {
+	if got := attempts.Load(); got != 2 {
 		t.Errorf("expected 2 attempts, got %d", got)
 	}
 }
@@ -195,7 +195,7 @@ func TestRetryOnError_Callback_SuccessFirstAttempt(t *testing.T) {
 func TestRetryOnError_Callback_RetryThenSuccess(t *testing.T) {
 	var events []RetryAttempt
 	var mu sync.Mutex
-	var attempts int32
+	var attempts atomic.Int32
 
 	wrapped := RetryOnError(DiscardLogger, 3, 10*time.Millisecond, time.Second, 2.0,
 		WithRetryCallback(func(a RetryAttempt) {
@@ -204,7 +204,7 @@ func TestRetryOnError_Callback_RetryThenSuccess(t *testing.T) {
 			mu.Unlock()
 		}),
 	)(FuncErrorJob(func() error {
-		count := atomic.AddInt32(&attempts, 1)
+		count := attempts.Add(1)
 		if count < 3 {
 			return errors.New("transient")
 		}
@@ -310,7 +310,7 @@ func TestCircuitBreaker_StateChangeCallback_ClosedToOpen(t *testing.T) {
 		panic("always fails")
 	}))
 
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		func() {
 			defer func() { recover() }()
 			wrapped.Run()
@@ -351,7 +351,7 @@ func TestCircuitBreaker_StateChangeCallback_HalfOpenToOpen(t *testing.T) {
 	}))
 
 	// Open circuit
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		func() {
 			defer func() { recover() }()
 			wrapped.Run()
@@ -404,7 +404,7 @@ func TestCircuitBreaker_StateChangeCallback_HalfOpenToClosed(t *testing.T) {
 	}))
 
 	// Open circuit
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		func() {
 			defer func() { recover() }()
 			wrapped.Run()
@@ -438,19 +438,19 @@ func TestCircuitBreaker_StateChangeCallback_HalfOpenToClosed(t *testing.T) {
 
 func TestCircuitBreaker_NoCallback(t *testing.T) {
 	// Verify CircuitBreaker works without callback (backward compat)
-	var executions int32
+	var executions atomic.Int32
 
 	wrapped := CircuitBreaker(DiscardLogger, 3, time.Hour)(
 		FuncJob(func() {
-			atomic.AddInt32(&executions, 1)
+			executions.Add(1)
 		}),
 	)
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		wrapped.Run()
 	}
 
-	if got := atomic.LoadInt32(&executions); got != 5 {
+	if got := executions.Load(); got != 5 {
 		t.Errorf("expected 5 executions, got %d", got)
 	}
 }
@@ -482,7 +482,7 @@ func TestCircuitBreakerHandle_Open(t *testing.T) {
 	}))
 
 	// Fail twice to open
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		func() {
 			defer func() { recover() }()
 			wrapped.Run()
@@ -515,7 +515,7 @@ func TestCircuitBreakerHandle_HalfOpen(t *testing.T) {
 	}))
 
 	// Open circuit
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		func() {
 			defer func() { recover() }()
 			wrapped.Run()
@@ -548,7 +548,7 @@ func TestCircuitBreakerHandle_Recovery(t *testing.T) {
 	}))
 
 	// Open circuit
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		func() {
 			defer func() { recover() }()
 			wrapped.Run()
@@ -586,7 +586,7 @@ func TestCircuitBreakerHandle_WithCallback(t *testing.T) {
 		panic("fail")
 	}))
 
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		func() {
 			defer func() { recover() }()
 			wrapped.Run()
@@ -630,11 +630,11 @@ func TestCircuitBreakerState_String(t *testing.T) {
 // --- RetryWithBackoff callback with unlimited retries ---
 
 func TestRetryWithBackoff_Callback_UnlimitedRetries(t *testing.T) {
-	var eventCount int32
+	var eventCount atomic.Int32
 
 	wrapped := RetryWithBackoff(DiscardLogger, -1, 1*time.Millisecond, 5*time.Millisecond, 2.0,
 		WithRetryCallback(func(a RetryAttempt) {
-			atomic.AddInt32(&eventCount, 1)
+			eventCount.Add(1)
 			// With unlimited retries and a failing job, WillRetry should be true
 			// until the job eventually succeeds
 			if a.Err != nil && !a.WillRetry {
@@ -642,7 +642,7 @@ func TestRetryWithBackoff_Callback_UnlimitedRetries(t *testing.T) {
 			}
 		}),
 	)(FuncJob(func() {
-		count := atomic.LoadInt32(&eventCount)
+		count := eventCount.Load()
 		if count < 5 {
 			panic("keep trying")
 		}
@@ -650,7 +650,7 @@ func TestRetryWithBackoff_Callback_UnlimitedRetries(t *testing.T) {
 
 	wrapped.Run()
 
-	if got := atomic.LoadInt32(&eventCount); got < 5 {
+	if got := eventCount.Load(); got < 5 {
 		t.Errorf("expected at least 5 events, got %d", got)
 	}
 }

--- a/retry_test.go
+++ b/retry_test.go
@@ -13,27 +13,27 @@ import (
 )
 
 func TestRetryWithBackoff_SuccessOnFirstAttempt(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	wrapped := RetryWithBackoff(DiscardLogger, 3, 10*time.Millisecond, time.Second, 2.0)(
 		FuncJob(func() {
-			atomic.AddInt32(&attempts, 1)
+			attempts.Add(1)
 		}),
 	)
 
 	wrapped.Run()
 
-	if got := atomic.LoadInt32(&attempts); got != 1 {
+	if got := attempts.Load(); got != 1 {
 		t.Errorf("expected 1 attempt, got %d", got)
 	}
 }
 
 func TestRetryWithBackoff_SuccessOnRetry(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	wrapped := RetryWithBackoff(DiscardLogger, 3, 10*time.Millisecond, time.Second, 2.0)(
 		FuncJob(func() {
-			count := atomic.AddInt32(&attempts, 1)
+			count := attempts.Add(1)
 			if count < 3 {
 				panic("transient failure")
 			}
@@ -42,17 +42,17 @@ func TestRetryWithBackoff_SuccessOnRetry(t *testing.T) {
 
 	wrapped.Run()
 
-	if got := atomic.LoadInt32(&attempts); got != 3 {
+	if got := attempts.Load(); got != 3 {
 		t.Errorf("expected 3 attempts, got %d", got)
 	}
 }
 
 func TestRetryWithBackoff_ExhaustsRetries(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	wrapped := RetryWithBackoff(DiscardLogger, 3, 1*time.Millisecond, time.Second, 2.0)(
 		FuncJob(func() {
-			atomic.AddInt32(&attempts, 1)
+			attempts.Add(1)
 			panic("always fails")
 		}),
 	)
@@ -71,11 +71,11 @@ func TestRetryWithBackoff_ExhaustsRetries(t *testing.T) {
 }
 
 func TestRetryWithBackoff_RetriesExhausted_AttemptCount(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	wrapped := RetryWithBackoff(DiscardLogger, 3, 1*time.Millisecond, time.Second, 2.0)(
 		FuncJob(func() {
-			atomic.AddInt32(&attempts, 1)
+			attempts.Add(1)
 			panic("always fails")
 		}),
 	)
@@ -86,7 +86,7 @@ func TestRetryWithBackoff_RetriesExhausted_AttemptCount(t *testing.T) {
 	}()
 
 	// maxRetries=3 means 4 total attempts (1 initial + 3 retries)
-	if got := atomic.LoadInt32(&attempts); got != 4 {
+	if got := attempts.Load(); got != 4 {
 		t.Errorf("expected 4 attempts (1 initial + 3 retries), got %d", got)
 	}
 }
@@ -165,12 +165,12 @@ func TestRetryWithBackoff_MaxDelayRespected(t *testing.T) {
 }
 
 func TestRetryWithBackoff_UnlimitedRetries(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	// maxRetries=-1 means unlimited retries (explicit opt-in)
 	wrapped := RetryWithBackoff(DiscardLogger, -1, 1*time.Millisecond, 5*time.Millisecond, 2.0)(
 		FuncJob(func() {
-			count := atomic.AddInt32(&attempts, 1)
+			count := attempts.Add(1)
 			if count < 20 {
 				panic("keep trying")
 			}
@@ -179,18 +179,18 @@ func TestRetryWithBackoff_UnlimitedRetries(t *testing.T) {
 
 	wrapped.Run()
 
-	if got := atomic.LoadInt32(&attempts); got != 20 {
+	if got := attempts.Load(); got != 20 {
 		t.Errorf("expected 20 attempts, got %d", got)
 	}
 }
 
 func TestRetryWithBackoff_NoRetries(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	// maxRetries=0 means no retries (safe default) - execute once and fail
 	wrapped := RetryWithBackoff(DiscardLogger, 0, 1*time.Millisecond, 5*time.Millisecond, 2.0)(
 		FuncJob(func() {
-			atomic.AddInt32(&attempts, 1)
+			attempts.Add(1)
 			panic("fail immediately")
 		}),
 	)
@@ -204,42 +204,42 @@ func TestRetryWithBackoff_NoRetries(t *testing.T) {
 	wrapped.Run()
 
 	// Should have executed exactly once (no retries)
-	if got := atomic.LoadInt32(&attempts); got != 1 {
+	if got := attempts.Load(); got != 1 {
 		t.Errorf("expected 1 attempt with maxRetries=0, got %d", got)
 	}
 }
 
 func TestCircuitBreaker_NormalOperation(t *testing.T) {
-	var executions int32
+	var executions atomic.Int32
 
 	wrapped := CircuitBreaker(DiscardLogger, 3, time.Minute)(
 		FuncJob(func() {
-			atomic.AddInt32(&executions, 1)
+			executions.Add(1)
 		}),
 	)
 
 	// Multiple successful executions
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		wrapped.Run()
 	}
 
-	if got := atomic.LoadInt32(&executions); got != 5 {
+	if got := executions.Load(); got != 5 {
 		t.Errorf("expected 5 executions, got %d", got)
 	}
 }
 
 func TestCircuitBreaker_OpensAfterThreshold(t *testing.T) {
-	var executions int32
+	var executions atomic.Int32
 
 	wrapped := CircuitBreaker(DiscardLogger, 3, time.Hour)(
 		FuncJob(func() {
-			atomic.AddInt32(&executions, 1)
+			executions.Add(1)
 			panic("always fails")
 		}),
 	)
 
 	// Fail 3 times to open circuit
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		func() {
 			defer func() { recover() }()
 			wrapped.Run()
@@ -252,20 +252,20 @@ func TestCircuitBreaker_OpensAfterThreshold(t *testing.T) {
 	wrapped.Run()
 
 	// Should only have 3 executions (before circuit opened)
-	if got := atomic.LoadInt32(&executions); got != 3 {
+	if got := executions.Load(); got != 3 {
 		t.Errorf("expected 3 executions (circuit should be open), got %d", got)
 	}
 }
 
 func TestCircuitBreaker_HalfOpenRecovery(t *testing.T) {
-	var executions int32
+	var executions atomic.Int32
 	var shouldFail bool
 	var mu sync.Mutex
 
 	cooldown := 100 * time.Millisecond
 	wrapped := CircuitBreaker(DiscardLogger, 2, cooldown)(
 		FuncJob(func() {
-			atomic.AddInt32(&executions, 1)
+			executions.Add(1)
 			mu.Lock()
 			fail := shouldFail
 			mu.Unlock()
@@ -281,7 +281,7 @@ func TestCircuitBreaker_HalfOpenRecovery(t *testing.T) {
 	mu.Unlock()
 
 	// Fail twice to open circuit
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		func() {
 			defer func() { recover() }()
 			wrapped.Run()
@@ -307,24 +307,24 @@ func TestCircuitBreaker_HalfOpenRecovery(t *testing.T) {
 	wrapped.Run()
 
 	// Expected: 2 (initial failures) + 1 (half-open recovery) + 2 (after close) = 5
-	if got := atomic.LoadInt32(&executions); got != 5 {
+	if got := executions.Load(); got != 5 {
 		t.Errorf("expected 5 executions, got %d", got)
 	}
 }
 
 func TestCircuitBreaker_HalfOpenFailure(t *testing.T) {
-	var executions int32
+	var executions atomic.Int32
 
 	cooldown := 100 * time.Millisecond
 	wrapped := CircuitBreaker(DiscardLogger, 2, cooldown)(
 		FuncJob(func() {
-			atomic.AddInt32(&executions, 1)
+			executions.Add(1)
 			panic("always fails")
 		}),
 	)
 
 	// Fail twice to open circuit
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		func() {
 			defer func() { recover() }()
 			wrapped.Run()
@@ -347,21 +347,21 @@ func TestCircuitBreaker_HalfOpenFailure(t *testing.T) {
 	wrapped.Run() // Should be skipped
 
 	// Expected: 2 (initial) + 1 (half-open attempt) = 3
-	if got := atomic.LoadInt32(&executions); got != 3 {
+	if got := executions.Load(); got != 3 {
 		t.Errorf("expected 3 executions, got %d", got)
 	}
 }
 
 func TestCircuitBreaker_SuccessResetsFailures(t *testing.T) {
-	var executions int32
-	var failCount int32
+	var executions atomic.Int32
+	var failCount atomic.Int32
 	var mu sync.Mutex
 
 	wrapped := CircuitBreaker(DiscardLogger, 3, time.Hour)(
 		FuncJob(func() {
-			atomic.AddInt32(&executions, 1)
+			executions.Add(1)
 			mu.Lock()
-			count := atomic.AddInt32(&failCount, 1)
+			count := failCount.Add(1)
 			mu.Unlock()
 			if count == 2 || count == 5 {
 				// Fail on 2nd and 5th execution
@@ -371,7 +371,7 @@ func TestCircuitBreaker_SuccessResetsFailures(t *testing.T) {
 	)
 
 	// Execute with some failures
-	for i := 0; i < 6; i++ {
+	for range 6 {
 		func() {
 			defer func() { recover() }()
 			wrapped.Run()
@@ -379,39 +379,37 @@ func TestCircuitBreaker_SuccessResetsFailures(t *testing.T) {
 	}
 
 	// All executions should happen because failures are reset by successes
-	if got := atomic.LoadInt32(&executions); got != 6 {
+	if got := executions.Load(); got != 6 {
 		t.Errorf("expected 6 executions, got %d", got)
 	}
 }
 
 func TestCircuitBreaker_ConcurrentSafe(t *testing.T) {
-	var executions int32
+	var executions atomic.Int32
 
 	wrapped := CircuitBreaker(DiscardLogger, 5, time.Millisecond)(
 		FuncJob(func() {
-			atomic.AddInt32(&executions, 1)
+			executions.Add(1)
 		}),
 	)
 
 	var wg sync.WaitGroup
-	for i := 0; i < 100; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 100 {
+		wg.Go(func() {
 			wrapped.Run()
-		}()
+		})
 	}
 	wg.Wait()
 
 	// All should execute since no failures
-	if got := atomic.LoadInt32(&executions); got != 100 {
+	if got := executions.Load(); got != 100 {
 		t.Errorf("expected 100 executions, got %d", got)
 	}
 }
 
 func TestRetryWithBackoff_IntegrationWithCron(t *testing.T) {
 	clock := NewFakeClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
-	var executions int32
+	var executions atomic.Int32
 
 	// Chain order: Recover is outermost (catches final re-panics),
 	// RetryWithBackoff is innermost (sees panics from job, retries).
@@ -424,7 +422,7 @@ func TestRetryWithBackoff_IntegrationWithCron(t *testing.T) {
 	)
 
 	c.AddFunc("@every 1h", func() {
-		count := atomic.AddInt32(&executions, 1)
+		count := executions.Add(1)
 		if count < 3 {
 			panic("transient failure")
 		}
@@ -438,14 +436,14 @@ func TestRetryWithBackoff_IntegrationWithCron(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// Should have 3 executions (2 retries + 1 success)
-	if got := atomic.LoadInt32(&executions); got != 3 {
+	if got := executions.Load(); got != 3 {
 		t.Errorf("expected 3 executions, got %d", got)
 	}
 }
 
 func TestCircuitBreaker_IntegrationWithCron(t *testing.T) {
 	clock := NewFakeClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
-	var executions int32
+	var executions atomic.Int32
 
 	// Chain order: Recover is outermost (catches re-panics from circuit breaker),
 	// CircuitBreaker is innermost (sees panics from job, tracks failures).
@@ -458,7 +456,7 @@ func TestCircuitBreaker_IntegrationWithCron(t *testing.T) {
 	)
 
 	c.AddFunc("@every 1h", func() {
-		atomic.AddInt32(&executions, 1)
+		executions.Add(1)
 		panic("always fails")
 	})
 
@@ -467,13 +465,13 @@ func TestCircuitBreaker_IntegrationWithCron(t *testing.T) {
 
 	// Trigger job multiple times
 	time.Sleep(50 * time.Millisecond)
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		clock.Advance(time.Hour)
 		time.Sleep(50 * time.Millisecond)
 	}
 
 	// Should have 2 executions before circuit opens
-	if got := atomic.LoadInt32(&executions); got != 2 {
+	if got := executions.Load(); got != 2 {
 		t.Errorf("expected 2 executions (circuit should open), got %d", got)
 	}
 }
@@ -482,18 +480,18 @@ func TestCircuitBreaker_IntegrationWithCron(t *testing.T) {
 // This kills CONDITIONALS_BOUNDARY mutation where `>= threshold` could become `> threshold`.
 // When failures == threshold exactly, isHalfOpen should return true.
 func TestCircuitBreaker_BoundaryThresholdExact(t *testing.T) {
-	var executions int32
+	var executions atomic.Int32
 	threshold := 2 // Use small threshold for clarity
 
 	wrapped := CircuitBreaker(DiscardLogger, threshold, time.Hour)(
 		FuncJob(func() {
-			atomic.AddInt32(&executions, 1)
+			executions.Add(1)
 			panic("always fails")
 		}),
 	)
 
 	// Fail exactly `threshold` times (2 times)
-	for i := 0; i < threshold; i++ {
+	for range threshold {
 		func() {
 			defer func() { recover() }()
 			wrapped.Run()
@@ -505,12 +503,12 @@ func TestCircuitBreaker_BoundaryThresholdExact(t *testing.T) {
 	// With mutation >= → >: isHalfOpen would return false (2 > 2 is false)
 	// and circuit would incorrectly allow execution
 
-	execsBefore := atomic.LoadInt32(&executions)
+	execsBefore := executions.Load()
 
 	// This run should be SKIPPED if circuit is correctly open
 	wrapped.Run()
 
-	execsAfter := atomic.LoadInt32(&executions)
+	execsAfter := executions.Load()
 
 	// If circuit is correctly open, executions should NOT increase
 	if execsAfter != execsBefore {
@@ -529,7 +527,7 @@ func TestCircuitBreaker_BoundaryThresholdExact(t *testing.T) {
 // This kills CONDITIONALS_BOUNDARY mutation where `>= threshold` could become `> threshold`.
 // When failures == threshold, wasOpen should return true on successful reset.
 func TestCircuitBreaker_ResetOnSuccessBoundary(t *testing.T) {
-	var executions int32
+	var executions atomic.Int32
 	var shouldFail atomic.Bool
 	threshold := 2
 	cooldown := 50 * time.Millisecond
@@ -538,7 +536,7 @@ func TestCircuitBreaker_ResetOnSuccessBoundary(t *testing.T) {
 
 	wrapped := CircuitBreaker(DiscardLogger, threshold, cooldown)(
 		FuncJob(func() {
-			atomic.AddInt32(&executions, 1)
+			executions.Add(1)
 			if shouldFail.Load() {
 				panic("controlled failure")
 			}
@@ -546,7 +544,7 @@ func TestCircuitBreaker_ResetOnSuccessBoundary(t *testing.T) {
 	)
 
 	// Fail exactly threshold times to open circuit
-	for i := 0; i < threshold; i++ {
+	for range threshold {
 		func() {
 			defer func() { recover() }()
 			wrapped.Run()
@@ -560,12 +558,12 @@ func TestCircuitBreaker_ResetOnSuccessBoundary(t *testing.T) {
 	// Set up to succeed
 	shouldFail.Store(false)
 
-	execsBefore := atomic.LoadInt32(&executions)
+	execsBefore := executions.Load()
 
 	// Execute in half-open state - should succeed and reset circuit
 	wrapped.Run()
 
-	execsAfter := atomic.LoadInt32(&executions)
+	execsAfter := executions.Load()
 
 	// Execution should have happened (half-open allows one attempt)
 	if execsAfter != execsBefore+1 {
@@ -576,7 +574,7 @@ func TestCircuitBreaker_ResetOnSuccessBoundary(t *testing.T) {
 	// Now circuit should be closed, run again to verify
 	wrapped.Run()
 
-	execsFinal := atomic.LoadInt32(&executions)
+	execsFinal := executions.Load()
 	if execsFinal != execsAfter+1 {
 		t.Errorf("circuit should be closed after successful reset: expected %d, got %d",
 			execsAfter+1, execsFinal)
@@ -586,19 +584,19 @@ func TestCircuitBreaker_ResetOnSuccessBoundary(t *testing.T) {
 // TestCircuitBreaker_IsOpenBoundary tests retry.go:259 (isOpen) at exact threshold.
 // Combined with cooldown to verify open state detection at boundary.
 func TestCircuitBreaker_IsOpenBoundary(t *testing.T) {
-	var executions int32
+	var executions atomic.Int32
 	threshold := 3
 	cooldown := 100 * time.Millisecond
 
 	wrapped := CircuitBreaker(DiscardLogger, threshold, cooldown)(
 		FuncJob(func() {
-			atomic.AddInt32(&executions, 1)
+			executions.Add(1)
 			panic("always fails")
 		}),
 	)
 
 	// Fail exactly threshold times
-	for i := 0; i < threshold; i++ {
+	for range threshold {
 		func() {
 			defer func() { recover() }()
 			wrapped.Run()
@@ -606,14 +604,14 @@ func TestCircuitBreaker_IsOpenBoundary(t *testing.T) {
 	}
 
 	// Verify exactly threshold executions happened
-	if got := atomic.LoadInt32(&executions); got != int32(threshold) {
+	if got := executions.Load(); got != int32(threshold) {
 		t.Fatalf("expected %d executions, got %d", threshold, got)
 	}
 
 	// Circuit should be open - next call should be skipped (within cooldown)
 	wrapped.Run()
 
-	if got := atomic.LoadInt32(&executions); got != int32(threshold) {
+	if got := executions.Load(); got != int32(threshold) {
 		t.Errorf("circuit should be open at exact threshold, executions should stay at %d, got %d",
 			threshold, got)
 	}
@@ -627,7 +625,7 @@ func TestCircuitBreaker_IsOpenBoundary(t *testing.T) {
 	}()
 
 	// Should have one more execution (half-open attempt)
-	if got := atomic.LoadInt32(&executions); got != int32(threshold)+1 {
+	if got := executions.Load(); got != int32(threshold)+1 {
 		t.Errorf("half-open state should allow execution, expected %d, got %d",
 			threshold+1, got)
 	}
@@ -728,28 +726,28 @@ func TestPanicWithStackAlias(t *testing.T) {
 // --- RetryOnError tests ---
 
 func TestRetryOnError_SuccessOnFirstAttempt(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	wrapped := RetryOnError(DiscardLogger, 3, 10*time.Millisecond, time.Second, 2.0)(
 		FuncErrorJob(func() error {
-			atomic.AddInt32(&attempts, 1)
+			attempts.Add(1)
 			return nil
 		}),
 	)
 
 	wrapped.Run()
 
-	if got := atomic.LoadInt32(&attempts); got != 1 {
+	if got := attempts.Load(); got != 1 {
 		t.Errorf("expected 1 attempt, got %d", got)
 	}
 }
 
 func TestRetryOnError_SuccessOnRetry(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	wrapped := RetryOnError(DiscardLogger, 3, 10*time.Millisecond, time.Second, 2.0)(
 		FuncErrorJob(func() error {
-			count := atomic.AddInt32(&attempts, 1)
+			count := attempts.Add(1)
 			if count < 3 {
 				return errors.New("transient failure")
 			}
@@ -759,17 +757,17 @@ func TestRetryOnError_SuccessOnRetry(t *testing.T) {
 
 	wrapped.Run()
 
-	if got := atomic.LoadInt32(&attempts); got != 3 {
+	if got := attempts.Load(); got != 3 {
 		t.Errorf("expected 3 attempts, got %d", got)
 	}
 }
 
 func TestRetryOnError_ExhaustsRetries(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	wrapped := RetryOnError(DiscardLogger, 3, 1*time.Millisecond, time.Second, 2.0)(
 		FuncErrorJob(func() error {
-			atomic.AddInt32(&attempts, 1)
+			attempts.Add(1)
 			return errors.New("always fails")
 		}),
 	)
@@ -793,17 +791,17 @@ func TestRetryOnError_ExhaustsRetries(t *testing.T) {
 	}
 
 	// maxRetries=3 means 4 total attempts (1 initial + 3 retries)
-	if got := atomic.LoadInt32(&attempts); got != 4 {
+	if got := attempts.Load(); got != 4 {
 		t.Errorf("expected 4 attempts (1 initial + 3 retries), got %d", got)
 	}
 }
 
 func TestRetryOnError_NoRetries(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	wrapped := RetryOnError(DiscardLogger, 0, 1*time.Millisecond, 5*time.Millisecond, 2.0)(
 		FuncErrorJob(func() error {
-			atomic.AddInt32(&attempts, 1)
+			attempts.Add(1)
 			return errors.New("fail immediately")
 		}),
 	)
@@ -814,17 +812,17 @@ func TestRetryOnError_NoRetries(t *testing.T) {
 		wrapped.Run()
 	}()
 
-	if got := atomic.LoadInt32(&attempts); got != 1 {
+	if got := attempts.Load(); got != 1 {
 		t.Errorf("expected 1 attempt with maxRetries=0, got %d", got)
 	}
 }
 
 func TestRetryOnError_UnlimitedRetries(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	wrapped := RetryOnError(DiscardLogger, -1, 1*time.Millisecond, 5*time.Millisecond, 2.0)(
 		FuncErrorJob(func() error {
-			count := atomic.AddInt32(&attempts, 1)
+			count := attempts.Add(1)
 			if count < 20 {
 				return errors.New("keep trying")
 			}
@@ -834,24 +832,24 @@ func TestRetryOnError_UnlimitedRetries(t *testing.T) {
 
 	wrapped.Run()
 
-	if got := atomic.LoadInt32(&attempts); got != 20 {
+	if got := attempts.Load(); got != 20 {
 		t.Errorf("expected 20 attempts, got %d", got)
 	}
 }
 
 func TestRetryOnError_PassesThroughRegularJob(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	// Regular FuncJob doesn't implement ErrorJob
 	regularJob := FuncJob(func() {
-		atomic.AddInt32(&attempts, 1)
+		attempts.Add(1)
 	})
 
 	wrapped := RetryOnError(DiscardLogger, 3, 10*time.Millisecond, time.Second, 2.0)(regularJob)
 
 	wrapped.Run()
 
-	if got := atomic.LoadInt32(&attempts); got != 1 {
+	if got := attempts.Load(); got != 1 {
 		t.Errorf("expected 1 attempt (pass-through), got %d", got)
 	}
 }
@@ -926,7 +924,7 @@ func TestRetryOnError_MaxDelayRespected(t *testing.T) {
 
 func TestRetryOnError_IntegrationWithCron(t *testing.T) {
 	clock := NewFakeClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
-	var executions int32
+	var executions atomic.Int32
 
 	c := New(
 		WithClock(clock),
@@ -937,7 +935,7 @@ func TestRetryOnError_IntegrationWithCron(t *testing.T) {
 	)
 
 	c.AddJob("@every 1h", FuncErrorJob(func() error {
-		count := atomic.AddInt32(&executions, 1)
+		count := executions.Add(1)
 		if count < 3 {
 			return errors.New("transient failure")
 		}
@@ -952,7 +950,7 @@ func TestRetryOnError_IntegrationWithCron(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// Should have 3 executions (2 retries + 1 success)
-	if got := atomic.LoadInt32(&executions); got != 3 {
+	if got := executions.Load(); got != 3 {
 		t.Errorf("expected 3 executions, got %d", got)
 	}
 }
@@ -961,8 +959,8 @@ func TestRetryOnError_ChainWithRecover(t *testing.T) {
 	// RetryOnError should compose with Recover for mixed job types.
 	// ErrorJob gets error-based retry; if Run() is called on a FuncErrorJob
 	// that returns an error, it panics, which Recover catches.
-	var errorJobAttempts int32
-	var regularJobAttempts int32
+	var errorJobAttempts atomic.Int32
+	var regularJobAttempts atomic.Int32
 
 	chain := NewChain(
 		Recover(DiscardLogger),
@@ -971,7 +969,7 @@ func TestRetryOnError_ChainWithRecover(t *testing.T) {
 
 	// ErrorJob: gets error-based retry
 	errorJob := chain.Then(FuncErrorJob(func() error {
-		count := atomic.AddInt32(&errorJobAttempts, 1)
+		count := errorJobAttempts.Add(1)
 		if count < 2 {
 			return errors.New("transient")
 		}
@@ -979,18 +977,18 @@ func TestRetryOnError_ChainWithRecover(t *testing.T) {
 	}))
 	errorJob.Run()
 
-	if got := atomic.LoadInt32(&errorJobAttempts); got != 2 {
+	if got := errorJobAttempts.Load(); got != 2 {
 		t.Errorf("ErrorJob: expected 2 attempts, got %d", got)
 	}
 
 	// Regular Job: passes through RetryOnError, Recover catches panic
 	regularJob := chain.Then(FuncJob(func() {
-		atomic.AddInt32(&regularJobAttempts, 1)
+		regularJobAttempts.Add(1)
 		panic("regular job failure")
 	}))
 	regularJob.Run() // Recover catches the panic
 
-	if got := atomic.LoadInt32(&regularJobAttempts); got != 1 {
+	if got := regularJobAttempts.Load(); got != 1 {
 		t.Errorf("Regular Job: expected 1 attempt (no retry), got %d", got)
 	}
 }

--- a/triggered_test.go
+++ b/triggered_test.go
@@ -60,8 +60,8 @@ func TestTriggeredEntry_NeverAutoRuns(t *testing.T) {
 	c := New(WithClock(clock), WithParser(secondParser))
 	defer c.Stop()
 
-	var runs int32
-	_, err := c.AddFunc("@triggered", func() { atomic.AddInt32(&runs, 1) }, WithName("never-auto"))
+	var runs atomic.Int32
+	_, err := c.AddFunc("@triggered", func() { runs.Add(1) }, WithName("never-auto"))
 	if err != nil {
 		t.Fatalf("add failed: %v", err)
 	}
@@ -73,7 +73,7 @@ func TestTriggeredEntry_NeverAutoRuns(t *testing.T) {
 	clock.Advance(10 * time.Second)
 	time.Sleep(20 * time.Millisecond)
 
-	if n := atomic.LoadInt32(&runs); n != 0 {
+	if n := runs.Load(); n != 0 {
 		t.Errorf("expected 0 auto runs, got %d", n)
 	}
 }
@@ -201,10 +201,10 @@ func TestTriggerEntry_WithMiddleware(t *testing.T) {
 
 	running := make(chan struct{})
 	unblock := make(chan struct{})
-	var runs int32
+	var runs atomic.Int32
 
 	id, err := c.AddFunc("@triggered", func() {
-		atomic.AddInt32(&runs, 1)
+		runs.Add(1)
 		running <- struct{}{}
 		<-unblock
 	})
@@ -230,7 +230,7 @@ func TestTriggerEntry_WithMiddleware(t *testing.T) {
 	close(unblock) // Let first job finish
 	time.Sleep(20 * time.Millisecond)
 
-	if n := atomic.LoadInt32(&runs); n != 1 {
+	if n := runs.Load(); n != 1 {
 		t.Errorf("expected 1 run (second skipped), got %d", n)
 	}
 }
@@ -307,11 +307,11 @@ func TestWithRunImmediately_Triggered(t *testing.T) {
 	c := New(WithClock(clock), WithParser(secondParser))
 	defer c.Stop()
 
-	var runs int32
+	var runs atomic.Int32
 	var once sync.Once
 	done := make(chan struct{})
 	_, err := c.AddFunc("@triggered", func() {
-		atomic.AddInt32(&runs, 1)
+		runs.Add(1)
 		once.Do(func() { close(done) })
 	}, WithRunImmediately())
 	if err != nil {
@@ -330,7 +330,7 @@ func TestWithRunImmediately_Triggered(t *testing.T) {
 		t.Fatal("immediate run did not fire within 1s")
 	}
 
-	if n := atomic.LoadInt32(&runs); n != 1 {
+	if n := runs.Load(); n != 1 {
 		t.Errorf("expected 1 immediate run, got %d", n)
 	}
 
@@ -339,7 +339,7 @@ func TestWithRunImmediately_Triggered(t *testing.T) {
 	clock.Advance(10 * time.Second)
 	time.Sleep(20 * time.Millisecond)
 
-	if n := atomic.LoadInt32(&runs); n != 1 {
+	if n := runs.Load(); n != 1 {
 		t.Errorf("expected still 1 run after advance, got %d", n)
 	}
 }
@@ -483,8 +483,8 @@ func TestTriggerEntry_MultipleTriggers(t *testing.T) {
 	c := New(WithClock(clock), WithParser(secondParser))
 	defer c.Stop()
 
-	var runs int32
-	_, err := c.AddFunc("@triggered", func() { atomic.AddInt32(&runs, 1) }, WithName("multi"))
+	var runs atomic.Int32
+	_, err := c.AddFunc("@triggered", func() { runs.Add(1) }, WithName("multi"))
 	if err != nil {
 		t.Fatalf("add failed: %v", err)
 	}
@@ -492,7 +492,7 @@ func TestTriggerEntry_MultipleTriggers(t *testing.T) {
 	c.Start()
 	clock.BlockUntil(1)
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		if err := c.TriggerEntryByName("multi"); err != nil {
 			t.Fatalf("trigger %d failed: %v", i, err)
 		}
@@ -500,7 +500,7 @@ func TestTriggerEntry_MultipleTriggers(t *testing.T) {
 	}
 
 	time.Sleep(20 * time.Millisecond)
-	if n := atomic.LoadInt32(&runs); n != 3 {
+	if n := runs.Load(); n != 3 {
 		t.Errorf("expected 3 runs, got %d", n)
 	}
 }

--- a/validate_test.go
+++ b/validate_test.go
@@ -4,6 +4,7 @@
 package cron
 
 import (
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -437,7 +438,7 @@ func TestValidateSpecPerformance(t *testing.T) {
 	start := time.Now()
 	iterations := 1000
 
-	for i := 0; i < iterations; i++ {
+	for range iterations {
 		for _, spec := range specs {
 			_ = ValidateSpec(spec)
 		}
@@ -520,9 +521,9 @@ func TestValidateSpecConcurrent(t *testing.T) {
 	}
 
 	done := make(chan bool)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		go func() {
-			for j := 0; j < 100; j++ {
+			for range 100 {
 				for _, spec := range specs {
 					_ = ValidateSpec(spec)
 					_ = AnalyzeSpec(spec)
@@ -532,7 +533,7 @@ func TestValidateSpecConcurrent(t *testing.T) {
 		}()
 	}
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		<-done
 	}
 }
@@ -624,13 +625,7 @@ func TestValidateSpecs(t *testing.T) {
 
 			// Verify no unexpected errors
 			for idx := range errors {
-				found := false
-				for _, wantIdx := range tt.wantErrIndices {
-					if idx == wantIdx {
-						found = true
-						break
-					}
-				}
+				found := slices.Contains(tt.wantErrIndices, idx)
 				if !found {
 					t.Errorf("unexpected error at index %d: %v", idx, errors[idx])
 				}
@@ -684,9 +679,9 @@ func TestValidateSpecsConcurrent(t *testing.T) {
 	specs := []string{"* * * * *", "invalid", "@hourly", "bad", "0 9 * * MON-FRI"}
 	done := make(chan bool)
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		go func() {
-			for j := 0; j < 100; j++ {
+			for range 100 {
 				errors := ValidateSpecs(specs)
 				// Should always have exactly 2 errors (indices 1 and 3)
 				if len(errors) != 2 {
@@ -697,7 +692,7 @@ func TestValidateSpecsConcurrent(t *testing.T) {
 		}()
 	}
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		<-done
 	}
 }

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -946,12 +946,12 @@ func TestWorkflow_ConcurrentExecutions(t *testing.T) {
 	c.Start()
 	defer c.Stop()
 
-	var count int32
+	var count atomic.Int32
 	c.AddFunc("@triggered", func() {
-		atomic.AddInt32(&count, 1)
+		count.Add(1)
 	}, WithName("a"))
 	c.AddFunc("@triggered", func() {
-		atomic.AddInt32(&count, 1)
+		count.Add(1)
 	}, WithName("b"))
 	_ = c.AddDependencyByName("b", "a", OnSuccess)
 
@@ -962,10 +962,10 @@ func TestWorkflow_ConcurrentExecutions(t *testing.T) {
 
 	// Wait for all jobs (5 * 2 = 10 jobs).
 	deadline := time.After(5 * time.Second)
-	for atomic.LoadInt32(&count) < 10 {
+	for count.Load() < 10 {
 		select {
 		case <-deadline:
-			t.Fatalf("timeout: only %d/10 jobs ran", atomic.LoadInt32(&count))
+			t.Fatalf("timeout: only %d/10 jobs ran", count.Load())
 		default:
 			time.Sleep(10 * time.Millisecond)
 		}

--- a/year_test.go
+++ b/year_test.go
@@ -399,9 +399,9 @@ func TestYearFieldConcurrent(t *testing.T) {
 	}
 
 	done := make(chan bool)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		go func() {
-			for j := 0; j < 100; j++ {
+			for range 100 {
 				from := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 				next := schedule.Next(from)
 				if next.IsZero() {
@@ -416,7 +416,7 @@ func TestYearFieldConcurrent(t *testing.T) {
 		}()
 	}
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		<-done
 	}
 }


### PR DESCRIPTION
## Description

Full Go 1.27 update in four commits:

1. **Toolchain go1.26.2 → go1.27.0** — CI resolves its Go version from `go.mod` via the shared `netresearch/.github` go-check workflow, so this moves CI to Go 1.27. Includes correcting the stale CI version claim in AGENTS.md.
2. **Minimum supported Go raised to 1.26** — with Go 1.27 released, the two most recent releases are 1.26 and 1.27; per the support policy stated in docs/FAQ.md the `go` directive moves from 1.25 to 1.26. **Breaking for consumers still on Go 1.25** — worth a minor version bump and a release-notes flag.
3. **`go fix` modernization** — mechanical rewrites across 20 test files: `for range n` (~70 sites), `wg.Go` (4 sites), `interface{}` → `any`, `atomic.AddInt32/LoadInt32` on plain ints → `atomic.Int32`/`Int64` methods (~60 sites), and one manual membership loop → `slices.Contains`. Production code was already idiomatic; no `errors.As` sites exist in this zero-dependency library.
4. **Review-round doc sweep** — an adversarial review found five surfaces still declaring the 1.25 floor (package godoc in doc.go, the go.mod snippet quoted in docs/FAQ.md, the docs/MIGRATION.md checklist, docs/PROJECT_INDEX.md, and the pre-go-check required-checks list in .github/BRANCH_PROTECTION.md, now rewritten to match the live main ruleset) plus the missing CHANGELOG entry; all fixed.

## Type of Change

- [x] Breaking change (raises the minimum supported Go version)
- [x] Refactoring (no functional changes)

## Related Issues

None.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run `make verify` and all checks pass
- [ ] I have added tests covering my changes — not applicable, no behavior change
- [x] I have updated documentation as needed
- [x] My commits follow conventional commit format

## Testing

`go build ./...`, `go vet ./...`, `golangci-lint run` (0 issues) and `go test -race ./...` (46s, all pass) under go1.27.0 on the final tree; `go mod tidy` is a no-op; govulncheck clean. An independent review agent verified every mechanical rewrite class (range bounds loop-invariant, no index use-after-loop, wg.Go closure capture identical, the one `Add(2)` site correctly left unconverted, no weakened assertions).

## Additional Notes

A local golangci-lint built with Go < 1.27 refuses the config after this lands — rebuild with `GOTOOLCHAIN=go1.27.0 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`. CI is unaffected (go-check uses `install-mode: goinstall`). The advisory SonarCloud check is red on new-code duplication (7.5% vs 3%) — the mechanical test rewrites count as "new code"; the duplication pre-existed in the old form. Not in the required-checks ruleset.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_01L7tF9XuJfAfFk4yuY5KfPK)_