### PR TITLE
ci: publish releases directly instead of drafting them

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,23 @@ on:
   push:
     tags: ['v*']
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to (re)release (e.g. v0.16.0); defaults to the triggering ref"
+        required: false
+        type: string
+        default: ""
 
 permissions: {}
 
 jobs:
   create:
     uses: netresearch/.github/.github/workflows/golib-create-release.yml@main
+    with:
+      tag: ${{ inputs.tag || '' }}
+      # Publish directly, like the app repos' release-go-app.yml — one shared
+      # behavior across the Go estate instead of drafts awaiting manual publish.
+      draft: false
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
The shared golib-create-release.yml defaults to `draft: true`, so every release here waited on a manual publish — while the app repos' shared release-go-app.yml publishes directly. This passes `draft: false` for one behavior across the Go estate and adds a workflow_dispatch `tag` input so an existing tag can be (re)released. First use: publishing the waiting v0.15.1 and v0.16.0 drafts via dispatch.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_01L7tF9XuJfAfFk4yuY5KfPK)_